### PR TITLE
use latest NetLogoHeadless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ crossPaths := false
 
 val netlogoSha = settingKey[String]("version of NetLogo we depend on")
 
-netlogoSha := "07de0278"
+netlogoSha := "735513c0"
 
 libraryDependencies ++= {
   val sha = netlogoSha.value

--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -82,7 +82,7 @@ object Compiler {
     if (commands)
       Handlers.commands(defs.head.statements)
     else
-      Handlers.reporter(defs.head.statements(1).args(0))
+      Handlers.reporter(defs.head.statements.stmts(1).args(0))
   }
 
 }

--- a/src/main/scala/Handlers.scala
+++ b/src/main/scala/Handlers.scala
@@ -41,7 +41,7 @@ object Handlers {
       case block: ast.CommandBlock =>
         commands(block.statements)
       case statements: ast.Statements =>
-        statements.map(Prims.generateCommand)
+        statements.stmts.map(Prims.generateCommand)
           .filter(_.nonEmpty)
           .mkString("\n")
     }

--- a/src/main/scala/Prims.scala
+++ b/src/main/scala/Prims.scala
@@ -170,7 +170,7 @@ object Prims {
     // This is so that we don't shuffle unnecessarily.  FD 10/31/2013
     val nonEmptyCommandBlock =
       s.args(1).asInstanceOf[ast.CommandBlock]
-        .statements.nonEmpty
+        .statements.stmts.nonEmpty
     val body = Handlers.fun(s.args(1))
     s"""AgentSet.ask(AgentSet.$name($other), $nonEmptyCommandBlock, $body);"""
   }


### PR DESCRIPTION
and make some compiler changes necessary to keep up with 
NetLogo/NetLogo@cb9b477619396dd71e7d4fd962521c176123fd8f
(SeqProxy elimination in AST classes)

merge by @FrankDuncan
