### PR TITLE
get newer headless jar that has some additional death tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ ivyLoggingLevel := UpdateLogging.Quiet
 // we're not cross-building for different Scala versions
 crossPaths := false
 
-val nlDependencyVersion = "5.1.0-e5b375c"
+val nlDependencyVersion = "5.1.0-36088e5"
 
 resolvers += bintray.Opts.resolver.repo("netlogo", "NetLogoHeadless")
 

--- a/src/test/scala/TortoiseFixture.scala
+++ b/src/test/scala/TortoiseFixture.scala
@@ -49,7 +49,7 @@ class TestCommands extends lang.TestCommands with TortoiseFinder {
     "Agentsets::RemoveDuplicates" -> "???",
     "Breeds::TestIsBreed" -> "???",
     "ComparingAgents::ComparingPatches" -> "???",
-    "DeadTurtles::DeadTurtles9" -> "???",
+    "Death::DeadTurtles9" -> "???",
     "Equality::two-dead-turtles-are-equal" -> "???",
     "Equality::dead-turtle-equals-nobody" -> "???",
     "Equality::two-dead-links-are-equal" -> "???",
@@ -73,6 +73,8 @@ class TestCommands extends lang.TestCommands with TortoiseFinder {
     "Turtles::Turtles7" -> "colors don't wrap to [0,140)",
     "Links::Links2" -> "colors don't wrap to [0,140)",
     // significant
+    "Death::DeadTurtles10" -> "converting agent to string lacks dead check",
+    "Death::DeadLinks1" -> "converting agent to string lacks dead check",
     "Agentsets::Agentsets4" -> "TOO SLOW",
     "Links::LinksInitBlock" -> "TOO SLOW",
     "Random::RandomNOfIsFairForTurtles" -> "TOO SLOW",


### PR DESCRIPTION
I'll merge this myself if Travis signs off. being cautious because the SHA of the old headless jar isn't one that seems to actually exist in the NetLogo repo, so it's hard for me to know exactly what other commits I'm getting here
