### PR TITLE
Wip test in browser

### DIFF
--- a/browsefailures
+++ b/browsefailures
@@ -1,0 +1,22 @@
+#!/bin/sh
+exec scala "$0" "$@"
+!#
+
+import
+  java.{ awt, io, net },
+    awt.Desktop,
+    io.File,
+    net.URI
+
+val fileArg = args(0)
+
+def openInBrowser(filepath: String): Unit = {
+  val uri = new URI(s"file://$fileArg")
+  println(uri)
+  Desktop.getDesktop.browse(uri)
+}
+
+if (new File(fileArg).exists())
+  openInBrowser(fileArg)
+else
+  System.err.println(s"Cannot open failure list in browser.  The file '$fileArg' does not exist.")

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,12 @@ bintray.Keys.bintrayOrganization in bintray.Keys.bintray := Some("netlogo")
 
 logBuffered in testOnly in Test := false
 
+(test in Test) <<= (test in Test).dependsOn {
+  Def.task[Unit] {
+    sbt.IO.delete(target.value / "last-test-run-reports")
+  }
+}
+
 FastMediumSlow.settings
 
 PublishVersioned.settings

--- a/openbrowser.sbt
+++ b/openbrowser.sbt
@@ -1,0 +1,11 @@
+
+lazy val browsableFailureReport = settingKey[File]("location for browser failure report")
+
+browsableFailureReport := {
+  target.value / "last-test-run-reports" / "index.html"
+}
+
+TaskKey[Unit]("browseFailures") := {
+  import scala.sys.process.Process
+  s"./browsefailures ${browsableFailureReport.value.getAbsolutePath}" ! streams.value.log
+}

--- a/src/test/scala/BrowserReporter.scala
+++ b/src/test/scala/BrowserReporter.scala
@@ -1,0 +1,63 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  java.io.{ File, PrintWriter }
+
+import
+  scala.collection.mutable.ArrayBuffer
+
+trait BrowserReporter {
+  protected def writeReportDocument(filename: String, failedTestReports: Map[String, Seq[String]]): Unit = {
+    val str = s"""|<!DOCTYPE html>
+                  |<html>
+                  |  <head><title>Tortoise Test Failures</title></head>
+                  |  <body>
+                  |    ${failedSuites(failedTestReports).mkString("\n")}
+                  |  </body>
+                  |</html>""".stripMargin
+    writeToFile(filename, str)
+  }
+
+  protected def writeFixtureDocument(filename: String, fixture: ArrayBuffer[String]): Unit = {
+    val str = s"""|<!DOCTYPE html>
+                  |<html>
+                  |  <head>
+                  |    <script type="text/javascript" src="../classes/js/tortoise-engine.js"></script>
+                  |    <script type="text/javascript">
+                  |      ${fixture.mkString("\n")}
+                  |    </script>
+                  |  </head>
+                  |</html>""".stripMargin
+    writeToFile(filename, str)
+  }
+
+  private def writeToFile(name: String, contents: String): Unit = {
+    val parent = new File("./target/last-test-run-reports")
+    val file   = new File(parent, genFileName(name))
+    parent.mkdirs()
+
+    val fileWriter = new PrintWriter(file)
+    fileWriter.write(contents)
+    fileWriter.close()
+  }
+
+  private def failedSuites(suite: Map[String, Seq[String]]): Iterable[String] =
+    suite.map {
+      case (suiteName: String, testNames: Seq[String]) =>
+        s"""|<h3>$suiteName</h3>
+            |<ul>${reportElements(testNames).mkString("\n")}</ul>""".stripMargin
+    }
+
+  private def reportElements(failedTestNames: Seq[String]): Seq[String] =
+    failedTestNames.map(s => s"""<li><a href="${genFileName(s)}">$s</a></li>""")
+
+
+  private def genFileName(s: String): String =
+    s.replaceAll("::", "_")
+      .replaceAll("\\s+", "-")
+      .replaceAll("\\(", "")
+      .replaceAll("\\)", "") ++ ".html"
+
+}

--- a/src/test/scala/TestLogger.scala
+++ b/src/test/scala/TestLogger.scala
@@ -1,0 +1,76 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  javax.script.ScriptException
+
+import
+  org.scalatest.exceptions.TestFailedException
+
+import
+  org.nlogo.tortoise.jsengine.nashorn.Nashorn
+
+import
+  scala.collection.mutable.ArrayBuffer
+
+private[tortoise] trait TestLogger extends BrowserReporter {
+  private val jsBlobs = ArrayBuffer[String]()
+
+  protected val nashorn = new Nashorn {
+    override def run(script: String): (String, String) = {
+      jsBlobs.append(script)
+      super.run(script)
+    }
+
+    override def eval(script: String): AnyRef = {
+      // This removes noise on DockingFixture tests
+      jsBlobs.append(script.
+        replaceAll("""expectedUpdates = .+$""", "expectedUpdates = [];").
+        replaceAll("""actualUpdates\s+= .+$""", "actualUpdates = [];"))
+      super.eval(script)
+    }
+  }
+
+  protected def annotate(note: String): Unit = {
+    jsBlobs.append(s"/* $note */")
+  }
+
+  protected def noteAtStart(note: String): Unit = {
+    s"/* $note */" +=: jsBlobs
+  }
+
+  protected def annotatePrevious(note: String): Unit = {
+    val previous = jsBlobs.remove(jsBlobs.length - 1)
+    annotate(note)
+    jsBlobs.append(previous)
+  }
+
+  protected def loggingFailures[A](suite: String, name: String, runTest: => A): A = {
+    try {
+      jsBlobs.clear()
+      runTest
+    }
+    catch {
+      case e@(_: TestFailedException | _: ScriptException | _: AssertionError) =>
+        testFailed(suite, name)
+        throw e
+    }
+  }
+
+  protected def testFailed(suite: String, name: String): Unit = {
+    writeFixtureDocument(name, jsBlobs)
+    FailureReporter(suite, name)
+  }
+}
+
+// This is not an inner object of TestLogger because each suite (DockingFixture vs. TortoiseFinder)
+// will overwrite the other
+private object FailureReporter extends BrowserReporter {
+  private var failures: Map[String, Seq[String]] = Map()
+
+  def apply(suite: String, name: String): Unit = {
+    failures += suite -> (name +: failures.get(suite).toSeq.flatten)
+    writeReportDocument("index", failures)
+  }
+}

--- a/src/test/scala/TortoiseFinder.scala
+++ b/src/test/scala/TortoiseFinder.scala
@@ -1,0 +1,122 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  org.scalatest.{ BeforeAndAfterAll, exceptions },
+    exceptions.TestPendingException
+
+import
+  org.nlogo.headless.lang.{ AbstractFixture, Command, Finder, LanguageTest, NormalMode, TestCommands => TCommands, TestMode, TestReporters => TReporters }
+
+private[tortoise] trait TortoiseFinder extends Finder with BeforeAndAfterAll with BrowserReporter with TestLogger {
+
+  protected def freebies: Map[String, String]
+
+  override def shouldRun(t: LanguageTest, mode: TestMode) =
+    mode == NormalMode && super.shouldRun(t, mode)
+
+  def genFixture(name: String): AbstractFixture = new TortoiseFixture(name, nashorn, notImplemented) {
+    override def checkResult(mode: TestMode, reporter: String, expectedResult: String, actualResult: AnyRef): Unit = {
+      annotatePrevious(s"""NetLogo reporter for: $reporter
+                          |expected result: $expectedResult
+                          |actualResult: $actualResult""".stripMargin)
+      super.checkResult(mode, reporter, expectedResult, actualResult)
+    }
+
+    override def runCommand(command: Command, mode: TestMode): Unit = {
+      annotate(s"NetLogo generated code for: ${command.command}")
+      super.runCommand(command, mode)
+    }
+  }
+
+  override def runTest(t: LanguageTest, mode: TestMode): Unit =
+    loggingFailures(t.suiteName, t.testName, { super.runTest(t, mode) })
+
+  override def withFixture[T](name: String)(body: (AbstractFixture) => T): T =
+    freebies.get(name.stripSuffix(" (NormalMode)")) match {
+      case None =>
+        body(genFixture(name))
+      case Some(x) if x.contains("ASSUMES OPTIMIZATION") =>
+        notImplemented("Can only yield the correct answer if the optimizer is enabled")
+      case Some(x) if x.contains("TOO SLOW") =>
+        notImplemented("TOO SLOW")
+      case Some(excuse) =>
+        try body(genFixture(name))
+        catch {
+          case _: TestPendingException => // ignore; we'll hit the fail() below
+          case ex: Exception =>
+            notImplemented(s"$ex: LAME EXCUSE: $excuse")
+        }
+        fail(s"LAME EXCUSE WASN'T NEEDED: $excuse")
+    }
+
+  protected def notImplemented(s: String): Nothing = {
+    info(s)
+    throw new TestPendingException
+  }
+
+}
+
+class TestReporters extends TReporters with TortoiseFinder {
+  override val freebies = Map[String, String](
+    // obscure
+    "Lists::Sort2" -> "sorting heterogeneous lists doesn't work",
+    "Lists::Sort3" -> "sorting heterogeneous lists doesn't work",
+    "Lists::Sort5" -> "sorting heterogeneous lists doesn't work",
+    // perhaps never to be supported
+    "RunResult::RunResult1" -> "run/runresult on strings not supported",
+    "RunResult::RunResult2" -> "run/runresult on strings not supported",
+    "RunResult::RunResult3" -> "run/runresult on strings not supported"
+  )
+}
+
+class TestCommands extends TCommands with TortoiseFinder {
+  override val freebies = Map[String, String](
+    // requires features
+    "Random::RandomNOfIsFairForAList" -> "`n-of` not implemented for lists",
+    // requires handling of non-local exit (see in JVM NetLogo: `NonLocalExit`, `_report`, `_foreach`, `_run`)
+    "Stop::ReportFromForeach" -> "no non-local exit from foreach",
+    // Significant: Requires the optimizer to be turned on
+    "Interaction::Interaction3b1"                                             -> "ASSUMES OPTIMIZATION: empty init block",
+    "Interaction::Interaction3b2"                                             -> "ASSUMES OPTIMIZATION: empty init block",
+    "RandomOrderInitialization::TestRandomOrderInitializationCreateLinksFrom" -> "ASSUMES OPTIMIZATION: empty init block",
+    "RandomOrderInitialization::TestRandomOrderInitializationCreateLinksTo"   -> "ASSUMES OPTIMIZATION: empty init block",
+    "RandomOrderInitialization::TestRandomOrderInitializationCreateLinksWith" -> "ASSUMES OPTIMIZATION: empty init block",
+    "TurtlesHere::TurtlesHereCheckOrder1"                                     -> "ASSUMES OPTIMIZATION: empty init block",
+    "TurtlesHere::TurtlesHereCheckOrder2"                                     -> "ASSUMES OPTIMIZATION: empty init block",
+    "TurtlesHere::TurtlesHereCheckOrder3"                                     -> "ASSUMES OPTIMIZATION: empty init block",
+    "TurtlesHere::TurtlesHereCheckOrder4"                                     -> "ASSUMES OPTIMIZATION: empty init block",
+    // significant; uncertain how to solve
+    "Random::RandomNOfIsFairForLinks" -> "TOO SLOW",
+    // requires Tortoise compiler changes
+    "CommandTasks::*ToString3" -> "command task string representation doesn't match",
+    "CommandTasks::*ToString4" -> "command task string representation doesn't match",
+    "CommandTasks::*ToString5" -> "command task string representation doesn't match",
+    "CommandTasks::*ToString6" -> "command task string representation doesn't match",
+    // needs 'headless' compiler changes
+    "ReporterTasks::CloseOverLocal1" -> "Creates a function named 'const', which is a reserved keyword in JavaScript",
+    "CommandTasks::command-task-body-gets-agent-type-check" -> "Necessary check must be moved up into the front-end of the compiler",
+    "Errors::task-variable-not-in-task"                     -> "Necessary check must be moved up into the front-end of the compiler",
+    "Let::LetOfVarToItself1"                                -> "Necessary check must be moved up into the front-end of the compiler",
+    "Let::LetOfVarToItself2"                                -> "Necessary check must be moved up into the front-end of the compiler",
+    "Let::LetOfVarToItself3"                                -> "Necessary check must be moved up into the front-end of the compiler",
+    "Let::LetOfVarToItselfInsideAsk"                        -> "Necessary check must be moved up into the front-end of the compiler",
+    "TypeChecking::SetVariable"                             -> "Necessary check must be moved up into the front-end of the compiler",
+    // perhaps never to be supported
+    "ControlStructures::Run1"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run2"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run3"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run4"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run5"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run6"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run7"                  -> "run/runresult on strings not supported",
+    "ControlStructures::Run8"                  -> "run/runresult on strings not supported",
+    "Run::LuisIzquierdoRun1"                   -> "run/runresult on strings not supported",
+    "Run::LuisIzquierdoRun2"                   -> "run/runresult on strings not supported",
+    "Run::LuisIzquierdoRunResult1"             -> "run/runresult on strings not supported",
+    "Run::LuisIzquierdoRunResult2"             -> "run/runresult on strings not supported",
+    "Run::run-evaluate-string-input-only-once" -> "run/runresult on strings not supported"
+  )
+}
+


### PR DESCRIPTION
See https://github.com/NetLogo/Tortoise/issues/82 . Currently, this opens up tests in the browser any time there are failures. Tests are written to the project's target directory. I can make one or both of those configurable, if that's desirable.
