### PR TITLE
Use json2 writer/parser to work around nashorn bug

### DIFF
--- a/src/test/scala/dock/DockingFixture.scala
+++ b/src/test/scala/dock/DockingFixture.scala
@@ -153,13 +153,47 @@ class DockingFixture(name: String, nashorn: Nashorn) extends Fixture(name) {
   }
 
   private def updatedJsonModels(expectedJson: String, actualJson: String) : (String, String) = {
-    nashorn.eval(s"expectedUpdates = JSON.parse('$expectedJson')")
-    nashorn.eval(s"actualUpdates   = JSON.parse('$actualJson')")
+    nashorn.eval(s"expectedUpdates = JSON.parse('${sortedJSON(expectedJson)}')")
+    nashorn.eval(s"actualUpdates   = JSON.parse('${sortedJSON(actualJson)}')")
     nashorn.eval("expectedModel.updates(expectedUpdates)")
     nashorn.eval("actualModel.updates(actualUpdates)")
     val expectedModel = nashorn.eval("JSON.stringify(expectedModel)").asInstanceOf[String]
     val actualModel = nashorn.eval("JSON.stringify(actualModel)").asInstanceOf[String]
     (expectedModel, actualModel)
+  }
+
+  // This is a workaround for a bug in Nashorn found in java 1.8.0u40
+  // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8068872 --RGG (4/21/15)
+  private def sortedJSON(rawJSON: String): String = {
+
+    import scala.math.Ordering
+    import org.json4s.{ JArray, JObject, JValue, native }, native.JsonMethods.{ compact, parse, render }
+
+    def denumerify(s: String): String =
+      if (s.forall(_.isDigit)) s"_$s" else s
+
+    val nashornOrdering = new Ordering[String] {
+      override def compare(x: String, y: String): Int =
+        try x.toInt.compare(y.toInt)
+        catch {
+          case e: java.lang.NumberFormatException => x.compareTo(y)
+        }
+    }
+
+    def sort(j: JValue): JValue =
+      j match {
+        case JArray(elems) =>
+          JArray(elems.map(sort))
+        case JObject(fields) =>
+          JObject(fields.sortBy(_._1)(nashornOrdering).map {
+            case (k, v) => (denumerify(k), sort(v))
+          })
+        case other =>
+          other
+      }
+
+    compact(render(sort(parse(rawJSON))))
+
   }
 
   // use single-patch world by default to keep generated JSON to a minimum


### PR DESCRIPTION
Tested locally, passes tests in java 1.8.0u40. Obviously we should wait for the Travis build to finish, but sometimes travis uses 1.8.0u31 and sometimes it uses 1.8.0u40, so there's no guarantee that the build will display the problem this is intended to fix.