### PR TITLE
enable -Ywarn-value-discard

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ version := "0.1"
 scalaVersion := "2.11.6"
 
 scalacOptions ++=
-  "-deprecation -unchecked -feature -Xcheckinit -encoding us-ascii -target:jvm-1.7 -Xlint -Xfatal-warnings -language:_"
+  "-deprecation -unchecked -feature -Xcheckinit -encoding us-ascii -target:jvm-1.7 -Xlint -Xfatal-warnings -Ywarn-value-discard -language:_"
   .split(" ").toSeq
 
 resourceDirectory in Test := baseDirectory.value / "resources" / "test"

--- a/src/test/scala/TestLogger.scala
+++ b/src/test/scala/TestLogger.scala
@@ -38,6 +38,7 @@ private[tortoise] trait TestLogger extends BrowserReporter {
 
   protected def noteAtStart(note: String): Unit = {
     s"/* $note */" +=: jsBlobs
+    ()
   }
 
   protected def annotatePrevious(note: String): Unit = {

--- a/src/test/scala/TortoiseFixture.scala
+++ b/src/test/scala/TortoiseFixture.scala
@@ -21,11 +21,12 @@ class TortoiseFixture(name: String, nashorn: Nashorn, notImplemented: (String) =
   private var program: Program = Program.empty
   private var procs: ProceduresMap = NoProcedures
 
-  override def declare(model: CModel) {
+  override def declare(model: CModel): Unit = {
     val (js, p, m) = cautiously(Compiler.compileProcedures(model))
     program = p
     procs = m
     nashorn.eval(js)
+    ()
   }
 
   override def readFromString(literal: String): AnyRef =
@@ -35,7 +36,7 @@ class TortoiseFixture(name: String, nashorn: Nashorn, notImplemented: (String) =
     lazy val js = Compiler.compileCommands(wrapCommand(command), procs, program)
     command.result match {
       case Success(_) =>
-        cautiously(nashorn.run(js))
+        cautiously{ nashorn.run(js); () }
       case CompileError(msg) =>
         expectCompileError(js, msg)
       case RuntimeError(msg) =>


### PR DESCRIPTION
this helps catch some common coding errors, and usually isn't
onerous to comply with, especially in non-GUI code