### PR TITLE
compiler should emit error-throwing stubs for unimplemented primitives

### DIFF
--- a/src/main/scala/CompiledModel.scala
+++ b/src/main/scala/CompiledModel.scala
@@ -52,21 +52,29 @@ object CompiledModel {
 
   private type CompiledModelV = CompileResult[CompiledModel]
 
-  def fromModel(model: Model, compiler: CompilerLike = Compiler): CompiledModelV = validate(compiler) {
+  def fromModel(model:         Model,
+                compiler:      CompilerLike = Compiler)
+      (implicit compilerFlags: CompilerFlags): CompiledModelV = validate(compiler) {
     (c) =>
       val (code, program, procedures) = c.compileProcedures(model)
       CompiledModel(code, model, program, procedures, c)
   }
 
-  def fromNlogoContents(contents: String, compiler: CompilerLike = Compiler): CompiledModelV = {
+  def fromNlogoContents(contents:      String,
+                        compiler:      CompilerLike  = Compiler)
+              (implicit compilerFlags: CompilerFlags): CompiledModelV = {
     val model = ModelReader.parseModel(contents, CompilerUtilities)
     fromModel(model)
   }
 
-  def fromCode(netlogoCode: String, compiler: CompilerLike = Compiler): CompiledModelV =
+  def fromCode(netlogoCode:   String,
+               compiler:      CompilerLike = Compiler)
+     (implicit compilerFlags: CompilerFlags): CompiledModelV =
     fromModel(Model(netlogoCode, List(View.square(16))))
 
-  def fromCompiledModel(netlogoCode: String, oldModel: CompiledModel): CompiledModelV = {
+  def fromCompiledModel(netlogoCode:   String,
+                        oldModel:      CompiledModel)
+              (implicit compilerFlags: CompilerFlags): CompiledModelV = {
     val CompiledModel(_, model, _, _, compiler) = oldModel
     fromModel(model.copy(code = netlogoCode), compiler)
   }

--- a/src/main/scala/CompilerLike.scala
+++ b/src/main/scala/CompilerLike.scala
@@ -7,8 +7,21 @@ import
     FrontEndInterface.ProceduresMap
 
 trait CompilerLike {
-  def compileReporter(logo: String, oldProcedures: ProceduresMap, program: Program): String
-  def compileCommands(logo: String, oldProcedures: ProceduresMap, program: Program): String
-  def compileProcedures(model: Model): (String, Program, ProceduresMap)
-  def compileProcedures(code: String): (String, Program, ProceduresMap) = compileProcedures(Model(code))
+  def compileReporter(logo: String, oldProcedures: ProceduresMap, program: Program)
+    (implicit compilerFlags: CompilerFlags): String
+
+  def compileCommands(logo: String, oldProcedures: ProceduresMap, program: Program)
+    (implicit compilerFlags: CompilerFlags): String
+
+  def compileProcedures(model: Model)
+    (implicit compilerFlags: CompilerFlags): (String, Program, ProceduresMap)
+
+  def compileProcedures(code: String)
+    (implicit compilerFlags: CompilerFlags): (String, Program, ProceduresMap) = compileProcedures(Model(code))
+}
+
+case class CompilerFlags(generateUnimplemented: Boolean)
+
+object CompilerFlags {
+  implicit val Default = CompilerFlags(generateUnimplemented = false)
 }

--- a/src/main/scala/Handlers.scala
+++ b/src/main/scala/Handlers.scala
@@ -11,7 +11,10 @@ trait Handlers extends EveryIDProvider {
 
   def prims: Prims
 
-  def fun(node: AstNode, isReporter: Boolean = false, isTask: Boolean = false): String = {
+  def fun(    node:          AstNode,
+              isReporter:    Boolean = false,
+              isTask:        Boolean = false)
+    (implicit compilerFlags: CompilerFlags): String = {
     val taskHeader =
       if (isTask)
         "var taskArguments = arguments;\n"
@@ -46,7 +49,7 @@ trait Handlers extends EveryIDProvider {
   // objects, representing the concrete syntax of square brackets, but at this stage of compilation
   // the brackets are irrelevant.  So when we see a block we just immediately recurse into it.
 
-  def commands(node: AstNode): String =
+  def commands(node: AstNode)(implicit compilerFlags: CompilerFlags): String =
     node match {
       case block: CommandBlock =>
         commands(block.statements)
@@ -56,7 +59,7 @@ trait Handlers extends EveryIDProvider {
           .mkString("\n")
     }
 
-  def reporter(node: AstNode): String = node match {
+  def reporter(node: AstNode)(implicit compilerFlags: CompilerFlags): String = node match {
     case block: ReporterBlock =>
       reporter(block.app)
     case app: ReporterApp =>


### PR DESCRIPTION
I wonder if these errors need to abort the process. I have models that have code that calls not-yet-implemented primitives but that code isn't always called. In addition to the warnings produced by the compiler I suggest the compiled code use stubs that signal an error when run for all the not-yet implemented features. This way one can test one's model in those conditions where those primitives aren't called.