### PR TITLE
upgrade to Scala 2.11.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 jdk: oraclejdk8
 language: scala
-scala: 2.11.6
+scala: 2.11.7
 env:
   global:
     - TRAVIS=true

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val commonSettings =
     version       := "0.1",
     // Compilation settings
     crossPaths    := false, // we're not cross-building for different Scala versions
-    scalaVersion  := "2.11.6",
+    scalaVersion  := "2.11.7",
     scalacOptions ++=
       "-deprecation -unchecked -feature -Xcheckinit -encoding us-ascii -target:jvm-1.7 -Xlint -Xfatal-warnings -Ywarn-value-discard -language:_".split(" ").toSeq,
     // Dependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("org.nlogo" % "publish-versioned-plugin" % "2.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.4")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 


### PR DESCRIPTION
Scala 2.11.7 has been published to Maven Central, but hasn't yet
been announced. it's still possible some last-minute regression
will be discovered, so even if this passes Travis, you might
wait to merge this until the release has actually been announced