### PR TITLE
Browser compiler parity

### DIFF
--- a/js/src/main/scala/BrowserRequests.scala
+++ b/js/src/main/scala/BrowserRequests.scala
@@ -1,0 +1,76 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  json.{ Jsonify, JsonReader, ShapeToJsonConverters, TortoiseJson, WidgetToJson },
+    JsonReader.{ OptionalJsonReader, tortoiseJsAsStringSeq, tortoiseJs2String },
+    ShapeToJsonConverters.{ readLinkShapes, readVectorShapes },
+    TortoiseJson.JsObject,
+    WidgetToJson.{ widget2Json, readWidgetJson, readWidgetsJson }
+
+import
+  org.nlogo.core.{ Model, Shape, Widget },
+    Shape.{ LinkShape, VectorShape }
+
+case class ExportRequest(
+  code:         String,
+  info:         Option[String],
+  widgets:      Seq[Widget],
+  turtleShapes: Option[Seq[VectorShape]],
+  linkShapes:   Option[Seq[LinkShape]]
+) {
+  def toModel: Model =
+    Model(
+      code         = code,
+      widgets      = widgets.toList,
+      info         = info                       getOrElse "",
+      turtleShapes = turtleShapes.map(_.toList) getOrElse Model.defaultShapes,
+      linkShapes   = linkShapes.map(_.toList)   getOrElse Model.defaultLinkShapes)
+}
+
+private[tortoise] trait RequestSharedImplicits {
+  implicit object optionalStringReader extends OptionalJsonReader[String] {
+    override val transform = tortoiseJs2String
+  }
+
+  implicit object optionVectorShapes extends OptionalJsonReader[Seq[VectorShape]] {
+    override val transform = readVectorShapes _
+  }
+
+  implicit object optionLinkShapes extends OptionalJsonReader[Seq[LinkShape]] {
+    override val transform = readLinkShapes _
+  }
+}
+
+object ExportRequest extends RequestSharedImplicits {
+  val read = Jsonify.reader[JsObject, ExportRequest]
+}
+
+case class CompilationRequest(
+  code:         String,
+  info:         Option[String],
+  widgets:      Seq[Widget],
+  commands:     Option[Seq[String]],
+  turtleShapes: Option[Seq[VectorShape]],
+  linkShapes:   Option[Seq[LinkShape]]
+) {
+
+  val allCommands: Seq[String] = commands.getOrElse(Seq())
+
+  def toModel: Model =
+    Model(
+      code         = code,
+      widgets      = widgets.toList,
+      info         = info                       getOrElse "",
+      turtleShapes = turtleShapes.map(_.toList) getOrElse Model.defaultShapes,
+      linkShapes   = linkShapes.map(_.toList)   getOrElse Model.defaultLinkShapes)
+}
+
+object CompilationRequest extends RequestSharedImplicits {
+  implicit object optionalSeqReader extends OptionalJsonReader[Seq[String]] {
+    override val transform = tortoiseJsAsStringSeq
+  }
+
+  val read = Jsonify.reader[JsObject, CompilationRequest]
+}

--- a/js/src/main/scala/Failure.scala
+++ b/js/src/main/scala/Failure.scala
@@ -1,0 +1,47 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  json.{ JsonReader, JsonWritable, JsonWriter, TortoiseJson },
+    TortoiseJson.{ fields, JsInt, JsObject, JsString }
+
+import
+  org.nlogo.core.CompilerException
+
+sealed trait Failure
+case class FailureString(str: String) extends Failure
+case class FailureException(exception: Throwable) extends Failure
+case class FailureCompilerException(exception: CompilerException) extends Failure
+
+object Failure {
+  implicit object compileFailure2Json extends JsonWriter[Failure] {
+    def apply(f: Failure): TortoiseJson =
+      f match {
+        case FailureCompilerException(ce) => ce.toJsonObj
+        case FailureException(e)          => e.toJsonObj
+        case FailureString(s)             =>
+          JsObject(fields("message" -> JsString(s)))
+      }
+  }
+
+  implicit object compileError2Json extends JsonWriter[Throwable] {
+    def apply(ex: Throwable): TortoiseJson =
+      ex match {
+        case compilerException: CompilerException =>
+          JsObject(fields(
+            "message" -> JsString(compilerException.getMessage),
+            "start"   -> JsInt(compilerException.start),
+            "end"     -> JsInt(compilerException.end)))
+        case otherException                       =>
+          JsObject(fields(
+            "message" -> JsString(otherException.getMessage)))
+      }
+  }
+
+  implicit def failure2Json(f: Failure): JsonWritable =
+    JsonWriter.convert(f)
+
+  implicit def exception2Json(ex: Throwable): JsonWritable =
+    JsonWriter.convert(ex)
+}

--- a/js/src/test/scala/BrowserCompilerTest.scala
+++ b/js/src/test/scala/BrowserCompilerTest.scala
@@ -124,8 +124,28 @@ object BrowserCompilerTest extends TestSuite {
       assert(parsedModel.linkShapes.last.name == "custom2")
     }
 
-    "testFromModelCompilationPreservesCustomShapes"-{
-      assert(false)
+    "testCompilationWithoutCommandsOK"-{
+      val compiledModel = withBrowserCompiler(_.fromModel(modelToCompilationRequest(validModel)))
+      assert(compiledModel[Boolean]("success"))
+      val commands      = compiledModel[JsArray]("commands")
+      assert(commands.elems.isEmpty)
+    }
+
+    "testCompilationPreservesCustomShapes"-{
+      val compiledModel = withBrowserCompiler(_.fromModel(modelToCompilationRequest(validModel)))
+      assert(compiledModel[Boolean]("success"))
+      val compiledJs = compiledModel[String]("result")
+      assert(compiledJs.contains("custom"))
+      assert(compiledJs.contains("custom2"))
+    }
+
+
+    "testCompilationSucceedsWithJustCode"-{
+      val compiledModel = withBrowserCompiler(_.fromModel(toNative(JsObject(fields(
+        "code" -> JsString("to foo fd 1 end"),
+        "widgets" -> JsArray(validModel.widgets.map(widget2Json(_).toJsonObj))
+        )))))
+      assert(compiledModel[Boolean]("success"))
     }
   }
 

--- a/netlogo-web/src/test/scala/ModelDumpTests.scala
+++ b/netlogo-web/src/test/scala/ModelDumpTests.scala
@@ -42,9 +42,10 @@ class ModelDumpTests extends FunSuite {
       try {
         val modelContents                = Source.fromFile(path).mkString
         val (compilationResult, widgets) = compilationFunction(Array[Object](modelContents))
-        assert(compilationResult("success").asInstanceOf[Boolean])
+        val modelResult = compilationResult("model").asInstanceOf[JMap[String,AnyRef]]
+        assert(modelResult.get("success").asInstanceOf[Boolean])
 
-        val genaratedJs = cleanJsNumbers(compilationResult("result").toString.trim)
+        val genaratedJs = cleanJsNumbers(modelResult.get("result").toString.trim)
         loggingGeneratedJs(genaratedJs, path) {
           assertResult(archivedCompilation(path))(genaratedJs)
         }

--- a/tortoise/src/main/scala/json/JsonReader.scala
+++ b/tortoise/src/main/scala/json/JsonReader.scala
@@ -129,4 +129,14 @@ object JsonReader extends LowPriorityImplicitReaders {
         case other          => nonArrayErrorString(other).failureNel[Seq[T]]
       }
   }
+
+  trait OptionalJsonReader[T] extends JsonReader[TortoiseJson, Option[T]] {
+    def transform: TortoiseJson => ValidationNel[String, T]
+
+    override def apply(json: TortoiseJson): ValidationNel[String, Option[T]] =
+      transform(json).map(vt => Some(vt))
+
+    override def read(key: String, json: Option[TortoiseJson]): ValidationNel[String, Option[T]] =
+      json.map(apply).getOrElse(None.successNel)
+  }
 }

--- a/tortoise/src/main/scala/json/JsonReader.scala
+++ b/tortoise/src/main/scala/json/JsonReader.scala
@@ -15,6 +15,8 @@ import
   TortoiseJson.{ JsArray, JsBool, JsDouble, JsInt, JsObject, JsString }
 
 trait LowPriorityImplicitReaders {
+  import JsonReader.JsonSequenceReader
+
   implicit object boolean2TortoiseJs extends JsonReader[TortoiseJson, Boolean] {
     def apply(t: TortoiseJson): ValidationNel[String, Boolean] = t match {
       case JsBool(b) => b.successNel
@@ -52,6 +54,14 @@ trait LowPriorityImplicitReaders {
       case JsString(s) => s.successNel
       case other       => s"could not convert $other to String".failureNel
     }
+  }
+
+  implicit object tortoiseJsAsStringSeq extends JsonSequenceReader[String] {
+    def nonArrayErrorString(json: TortoiseJson): String =
+      s"expected an array of strings, found $json"
+
+    def convertElem(json: TortoiseJson): ValidationNel[String, String] =
+      tortoiseJs2String(json)
   }
 
   implicit object tortoiseJsAsJsObject extends JsonReader[TortoiseJson, JsObject] {

--- a/tortoise/src/main/scala/json/ShapeToJsonConverters.scala
+++ b/tortoise/src/main/scala/json/ShapeToJsonConverters.scala
@@ -70,12 +70,12 @@ object ShapeToJsonConverters {
   }
 
   def readVectorShapes(json: TortoiseJson): ValidationNel[String, Seq[VectorShape]] =
-    readShapes(vectorReader, json)
+    readShapes(vectorShapes2Json, json)
 
   def readLinkShapes(json: TortoiseJson): ValidationNel[String, Seq[LinkShape]] =
-    readShapes(linkReader, json)
+    readShapes(linkShapes2Json, json)
 
-  private val vectorReader = new JsonSequenceReader[VectorShape] {
+  implicit val vectorShapes2Json = new JsonSequenceReader[VectorShape] {
     def convertElem(json: TortoiseJson): ValidationNel[String, VectorShape] =
       readVectorShape(json)
 
@@ -83,7 +83,7 @@ object ShapeToJsonConverters {
       s"Expected vector shapes as array of objects, got $json"
   }
 
-  private val linkReader   = new JsonSequenceReader[LinkShape] {
+  implicit val linkShapes2Json   = new JsonSequenceReader[LinkShape] {
     def convertElem(json: TortoiseJson): ValidationNel[String, LinkShape] =
       readLinkShape(json)
 

--- a/tortoise/src/main/scala/json/WidgetToJson.scala
+++ b/tortoise/src/main/scala/json/WidgetToJson.scala
@@ -3,6 +3,9 @@
 package org.nlogo.tortoise.json
 
 import
+  JsonReader.JsonSequenceReader
+
+import
   org.nlogo.core.{ Button, Chooser, Col, InputBox,
     InputBoxType, Monitor, Num, Output, Pen, Plot, Slider, Switch, TextBox, View, Widget }
 
@@ -24,6 +27,13 @@ object WidgetToJson {
           "Widgets must be represented as a JSON Object with type specified".failureNel[Widget]
       }
     }
+  }
+
+  implicit object readWidgetsJson extends JsonSequenceReader[Widget] {
+    def nonArrayErrorString(json: TortoiseJson): String =
+      s"expected an array of Widgets, found $json"
+
+    def convertElem(json: TortoiseJson): ValidationNel[String, Widget] = readWidgetJson(json)
   }
 
   def read(json: TortoiseJson): ValidationNel[String, Widget] =


### PR DESCRIPTION
The goal of this PR is to add the functions necessary for in-browser Galapagos to match server-backed Galapagos. The export-to-nlogo enhancement and preserve-custom-shapes bugfix were made without updates to BrowserCompiler, which are needed to replicate those functions on the client-side.