### PR TITLE
Improved plot errors

### DIFF
--- a/js/src/main/scala/Failure.scala
+++ b/js/src/main/scala/Failure.scala
@@ -9,14 +9,14 @@ import
 import
   org.nlogo.core.CompilerException
 
-sealed trait Failure
-case class FailureString(str: String) extends Failure
-case class FailureException(exception: Throwable) extends Failure
-case class FailureCompilerException(exception: CompilerException) extends Failure
+sealed trait TortoiseFailure
+case class FailureString(str: String) extends TortoiseFailure
+case class FailureException(exception: Throwable) extends TortoiseFailure
+case class FailureCompilerException(exception: CompilerException) extends TortoiseFailure
 
-object Failure {
-  implicit object compileFailure2Json extends JsonWriter[Failure] {
-    def apply(f: Failure): TortoiseJson =
+object TortoiseFailure {
+  implicit object compileFailure2Json extends JsonWriter[TortoiseFailure] {
+    def apply(f: TortoiseFailure): TortoiseJson =
       f match {
         case FailureCompilerException(ce) => ce.toJsonObj
         case FailureException(e)          => e.toJsonObj
@@ -39,7 +39,7 @@ object Failure {
       }
   }
 
-  implicit def failure2Json(f: Failure): JsonWritable =
+  implicit def failure2Json(f: TortoiseFailure): JsonWritable =
     JsonWriter.convert(f)
 
   implicit def exception2Json(ex: Throwable): JsonWritable =

--- a/js/src/test/scala/BrowserCompilerTest.scala
+++ b/js/src/test/scala/BrowserCompilerTest.scala
@@ -67,11 +67,10 @@ object BrowserCompilerTest extends TestSuite {
       val slider = Slider(display = "steps", varName = "steps")
       val compiledModel = compileModel(validModel.copy(widgets = slider::validModel.widgets))
       assert(isSuccess(compiledModel))
-      withWidget(compiledModel, "slider", slider =>
-        Seq("compiledStep", "compiledMax", "compiledMin").foreach { field =>
-          assert(slider[JsObject](field).apply[Boolean]("success"))
-          assert(slider[JsObject](field).apply[String]("result").nonEmpty)
-        })
+      withWidget(compiledModel, "slider", { slider =>
+        assert(slider[JsObject]("compilation").apply[Boolean]("success"))
+        assert(slider[JsObject]("compilation").apply[JsArray]("messages").elems.isEmpty)
+      })
     }
 
     "TestModelWithInvalidWidgets"-{
@@ -79,8 +78,8 @@ object BrowserCompilerTest extends TestSuite {
       val compiledModel = compileModel(validModel.copy(widgets = invalidSlider::validModel.widgets))
       assert(isSuccess(compiledModel))
       withWidget(compiledModel, "slider", {slider =>
-          assert(slider[JsObject]("compiledMin").apply[Boolean]("success") == false)
-          assert(slider[JsObject]("compiledMin").apply[JsArray]("result").elems.nonEmpty) })
+          assert(slider[JsObject]("compilation").apply[Boolean]("success") == false)
+          assert(slider[JsObject]("compilation").apply[JsArray]("messages").elems.nonEmpty) })
     }
 
     "testCompilesCommands"-{

--- a/jvm/src/test/scala/PlotCompilerTest.scala
+++ b/jvm/src/test/scala/PlotCompilerTest.scala
@@ -1,0 +1,85 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+package org.nlogo.tortoise
+
+import
+  WidgetCompilation.PlotWidgetCompilation
+
+import
+  jsengine.Nashorn
+
+import
+  json.WidgetSamples.{
+    pen  => penWidget,
+    plot => plotWidget
+  }
+
+import
+  org.scalatest.{ FunSuite, OneInstancePerTest }
+
+import
+  scalaz.{ NonEmptyList, Scalaz, ValidationNel },
+    Scalaz.ToValidationOps
+
+class PlotCompilerTest extends FunSuite with OneInstancePerTest {
+  class FakeOutput {
+    var alertsReceived = Seq[String]()
+
+    def alert(s: String): Unit =
+      alertsReceived = alertsReceived :+ s
+  }
+
+  lazy val output = new FakeOutput()
+
+  lazy val nashornEngine = {
+    val e = new Nashorn().engine
+    e.put("fakeOutput", output)
+    e.eval("modelConfig = { output: fakeOutput };")
+    e.eval("modelPlotOps = {};")
+    e.eval("function PlotOps() {};")
+    e.eval("function Plot() {};")
+    e
+  }
+
+  def compiledPlot(compilationV: ValidationNel[Exception, PlotWidgetCompilation]) =
+    new CompiledPlot(plotWidget, "abc", compilationV)
+
+  def plotJs(plot: CompiledPlot): String =
+    PlotCompiler.formatPlots(Seq(plot)).filter(_.provides == "modelConfig.plots").head.toJS
+
+  def compilePlotWidgetV(compilationV: ValidationNel[Exception, PlotWidgetCompilation]): String =
+    plotJs(compiledPlot(compilationV))
+
+  test("returns valid javascript when plots have errors") {
+    val generatedJs =
+      compilePlotWidgetV(new Exception("plot abc has problems").failureNel)
+    nashornEngine.eval(generatedJs)
+    assert(output.alertsReceived.head == "plot abc has problems")
+  }
+
+  test("returns valid javascript when pens have errors") {
+    val errantPen = new CompiledPen(penWidget, new Exception("pen has problems").failureNel)
+    val widgetCompilation =
+      PlotWidgetCompilation("function() {}", "function() {}", Seq(errantPen)).successNel
+    val generatedJs = compilePlotWidgetV(widgetCompilation)
+    nashornEngine.eval(generatedJs)
+    assert(output.alertsReceived.head == "pen has problems")
+  }
+
+  test("returns multiple errors when there are multiple pen errors") {
+    val errantPens = new CompiledPen(penWidget, NonEmptyList(new Exception("pen a has problems"), new Exception("pen b has problems")).failure)
+    val widgetCompilation =
+      PlotWidgetCompilation("function() {}", "function() {}", Seq(errantPens)).successNel
+    val generatedJs = compilePlotWidgetV(widgetCompilation)
+    nashornEngine.eval(generatedJs)
+    assert(output.alertsReceived.head == "pen a has problems, pen b has problems")
+  }
+
+  test("returns valid javascript when plots are correct") {
+    val widgetCompilation =
+      PlotWidgetCompilation("function() {}", "function() {}", Seq()).successNel
+    val generatedJs = compilePlotWidgetV(widgetCompilation)
+    nashornEngine.eval(generatedJs)
+    assert(output.alertsReceived.isEmpty)
+  }
+}

--- a/resources/test/dumps/AIDS.js
+++ b/resources/test/dumps/AIDS.js
@@ -32,27 +32,21 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('HIV-', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'HIV-')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('HIV-', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'HIV-')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return !SelfPrims.getVariable("infected?"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('HIV+', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'HIV+')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('HIV+', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'HIV+')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return SelfPrims.getVariable("known?"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('HIV?', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'HIV?')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('HIV?', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'HIV?')(function() {
         plotManager.plotValue((world.turtles().agentFilter(function() { return SelfPrims.getVariable("infected?"); }).size() - world.turtles().agentFilter(function() { return SelfPrims.getVariable("known?"); }).size()));;
@@ -64,9 +58,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Populations', undefined)(function() { plotManager.setYRange(0, (world.observer.getGlobal("initial-people") + 50));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "weeks", "people", true, 0.0, 52.0, 0.0, 350.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["infected?", "known?", "infection-length", "coupled?", "couple-length", "commitment", "coupling-tendency", "condom-use", "test-frequency", "partner"], [])(["initial-people", "average-commitment", "average-coupling-tendency", "average-condom-use", "average-test-frequency", "infection-chance", "symptoms-show", "slider-check-1", "slider-check-2", "slider-check-3", "slider-check-4"], ["initial-people", "average-commitment", "average-coupling-tendency", "average-condom-use", "average-test-frequency"], [], -12, 12, -12, 12, 17.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/AIDS.js
+++ b/resources/test/dumps/AIDS.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Ants Benchmark.js
+++ b/resources/test/dumps/Ants Benchmark.js
@@ -32,27 +32,11 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Food in each pile';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('food-in-pile1', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile1')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile1')(function() {}); });
-  }),
-  new PenBundle.Pen('food-in-pile2', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile2')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile2')(function() {}); });
-  }),
-  new PenBundle.Pen('food-in-pile3', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile3')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', 'food-in-pile3')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Food in each pile', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('food-in-pile1', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('food-in-pile2', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('food-in-pile3', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Food", false, 0.0, 100.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["carrying-food?", "drop-size"], [])(["diffusion-rate", "evaporation-rate", "plot?", "ants", "result"], ["diffusion-rate", "evaporation-rate", "plot?", "ants"], ["chemical", "food", "nest?", "nest-scent", "food-source-number"], -50, 50, -50, 50, 5.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Ants Benchmark.js
+++ b/resources/test/dumps/Ants Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/BZ Benchmark.js
+++ b/resources/test/dumps/BZ Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Boiling.js
+++ b/resources/test/dumps/Boiling.js
@@ -32,19 +32,13 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Average Heat';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('ave-heat', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Heat', 'ave-heat')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('ave-heat', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average Heat', 'ave-heat')(function() { plotManager.plotValue(Call(procedures.averageHeat));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Heat', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Heat', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Avg Heat", false, 0.0, 50.0, 0.0, 212.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])([], [], ["heat"], -40, 40, -40, 40, 5.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Boiling.js
+++ b/resources/test/dumps/Boiling.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Box Drawing Example.js
+++ b/resources/test/dumps/Box Drawing Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Bureaucrats Benchmark.js
+++ b/resources/test/dumps/Bureaucrats Benchmark.js
@@ -32,18 +32,14 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Average';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('average', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average', 'average')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('average', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average', 'average')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), (world.observer.getGlobal("total") / world.patches().size()));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average', undefined)(function() {}); });
-  };
+  var setup   = function() {};
   var update  = function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average', undefined)(function() {

--- a/resources/test/dumps/Bureaucrats Benchmark.js
+++ b/resources/test/dumps/Bureaucrats Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/CA1D Benchmark.js
+++ b/resources/test/dumps/CA1D Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Climate Change.js
+++ b/resources/test/dumps/Climate Change.js
@@ -32,19 +32,13 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Global Temperature';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Global Temperature', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Global Temperature', 'default')(function() { plotManager.plotValue(world.observer.getGlobal("temperature"));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Global Temperature', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Global Temperature', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", false, 0.0, 10.0, 10.0, 20.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "RAYS", singular: "ray", varNames: [] }, { name: "IRS", singular: "ir", varNames: [] }, { name: "HEATS", singular: "heat", varNames: [] }, { name: "CO2S", singular: "co2", varNames: [] }, { name: "CLOUDS", singular: "cloud", varNames: ["cloud-speed", "cloud-id"] }])([], [])(["sun-brightness", "albedo", "sky-top", "earth-top", "temperature"], ["sun-brightness", "albedo"], [], -24, 24, -8, 22, 11.0, true, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Climate Change.js
+++ b/resources/test/dumps/Climate Change.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Cooperation.js
+++ b/resources/test/dumps/Cooperation.js
@@ -32,26 +32,18 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Cows over time';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('greedy', plotOps.makePenOps, false, new PenBundle.State(93.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Cows over time', 'greedy')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('greedy', plotOps.makePenOps, false, new PenBundle.State(93.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Cows over time', 'greedy')(function() { plotManager.plotValue(world.turtleManager.turtlesOfBreed("GREEDY-COWS").size());; });
     });
   }),
-  new PenBundle.Pen('cooperative', plotOps.makePenOps, false, new PenBundle.State(13.5, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Cows over time', 'cooperative')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('cooperative', plotOps.makePenOps, false, new PenBundle.State(13.5, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Cows over time', 'cooperative')(function() { plotManager.plotValue(world.turtleManager.turtlesOfBreed("COOPERATIVE-COWS").size());; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Cows over time', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Cows over time', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Cows", true, 0.0, 10.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "COOPERATIVE-COWS", singular: "cooperative-cow", varNames: [] }, { name: "GREEDY-COWS", singular: "greedy-cow", varNames: [] }])(["energy"], [])(["cooperative-probability", "initial-cows", "low-high-threshold", "high-growth-chance", "stride-length", "max-grass-height", "reproduction-threshold", "grass-energy", "metabolism", "low-growth-chance", "reproduction-cost"], ["cooperative-probability", "initial-cows", "low-high-threshold", "high-growth-chance", "stride-length", "max-grass-height", "reproduction-threshold", "grass-energy", "metabolism", "low-growth-chance", "reproduction-cost"], ["grass"], -10, 10, -10, 10, 15.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Cooperation.js
+++ b/resources/test/dumps/Cooperation.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/DLA Simple.js
+++ b/resources/test/dumps/DLA Simple.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Diffusion on a Directed Network.js
+++ b/resources/test/dumps/Diffusion on a Directed Network.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Histogram';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Histogram', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Bar), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Histogram', 'default')(function() {
         plotManager.setXRange(0, NLMath.ceil((world.observer.getGlobal("max-val") + 0.5)));
@@ -43,12 +41,8 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Histogram', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Histogram', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "val", "# of nodes", false, 0.0, 10.0, 0.0, 10.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "ACTIVE-LINKS", singular: "active-link", varNames: [], isDirected: true }, { name: "INACTIVE-LINKS", singular: "inactive-link", varNames: [], isDirected: true }])(["val", "new-val"], ["current-flow"])(["link-chance", "grid-size", "diffusion-rate", "total-val", "max-val", "max-flow", "mean-flow"], ["link-chance", "grid-size", "diffusion-rate"], [], -10, 10, -10, 10, 20.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Diffusion on a Directed Network.js
+++ b/resources/test/dumps/Diffusion on a Directed Network.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Erosion.js
+++ b/resources/test/dumps/Erosion.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Ethnocentrism.js
+++ b/resources/test/dumps/Ethnocentrism.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Ethnocentrism.js
+++ b/resources/test/dumps/Ethnocentrism.js
@@ -32,48 +32,36 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Strategy Counts';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('CC', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', 'CC')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('CC', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Strategy Counts', 'CC')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("shape"), "circle"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('CD', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', 'CD')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('CD', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Strategy Counts', 'CD')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("shape"), "circle 2"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('DC', plotOps.makePenOps, false, new PenBundle.State(44.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', 'DC')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('DC', plotOps.makePenOps, false, new PenBundle.State(44.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Strategy Counts', 'DC')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("shape"), "square"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('DD', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', 'DD')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('DD', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Strategy Counts', 'DD')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("shape"), "square 2"); }).size());;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Strategy Counts', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "count", true, 0.0, 10.0, 0.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["ptr", "cooperate-with-same?", "cooperate-with-different?"], [])(["mutation-rate", "death-rate", "immigrants-per-day", "initial-ptr", "cost-of-giving", "gain-of-receiving", "immigrant-chance-cooperate-with-same", "immigrant-chance-cooperate-with-different", "meet", "meet-agg", "last100meet", "meetown", "meetown-agg", "last100meetown", "meetother", "meetother-agg", "last100meetother", "coopown", "coopown-agg", "last100coopown", "coopother", "coopother-agg", "defother", "defother-agg", "last100defother", "last100cc", "last100cd", "last100dc", "last100dd", "last100consist-ethno", "last100coop"], ["mutation-rate", "death-rate", "immigrants-per-day", "initial-ptr", "cost-of-giving", "gain-of-receiving", "immigrant-chance-cooperate-with-same", "immigrant-chance-cooperate-with-different"], [], 0, 50, 0, 50, 9.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Fire.js
+++ b/resources/test/dumps/Fire.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Fireflies.js
+++ b/resources/test/dumps/Fireflies.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Flashing Fireflies';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('flashing', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Flashing Fireflies', 'flashing')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('flashing', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Flashing Fireflies', 'flashing')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 45); }).size());;
@@ -46,9 +44,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Flashing Fireflies', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("number"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Flashing Fireflies', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number", false, 0.0, 100.0, 0.0, 1500.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["clock", "threshold", "reset-level", "window"], [])(["number", "cycle-length", "flash-length", "flashes-to-reset", "show-dark-fireflies?", "strategy"], ["number", "cycle-length", "flash-length", "flashes-to-reset", "show-dark-fireflies?", "strategy"], [], -35, 35, -35, 35, 6.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Fireflies.js
+++ b/resources/test/dumps/Fireflies.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Flocking.js
+++ b/resources/test/dumps/Flocking.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Follower.js
+++ b/resources/test/dumps/Follower.js
@@ -32,36 +32,28 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Turtle Count';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('unattached', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Count', 'unattached')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('unattached', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Count', 'unattached')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 125); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('heads', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Count', 'heads')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('heads', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Count', 'heads')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 45); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('bodies', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Count', 'bodies')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('bodies', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Count', 'bodies')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 95); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('tails', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Count', 'tails')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('tails', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Count', 'tails')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 65); }).size());;
@@ -73,9 +65,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Turtle Count', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("population"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Count', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "#", true, 0.0, 50.0, 0.0, 350.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["leader", "follower"], [])(["waver", "far-radius", "population", "near-radius"], ["waver", "far-radius", "population", "near-radius"], [], -30, 30, -30, 30, 8.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Follower.js
+++ b/resources/test/dumps/Follower.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Fur.js
+++ b/resources/test/dumps/Fur.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/GasLab Free Gas.js
+++ b/resources/test/dumps/GasLab Free Gas.js
@@ -65,9 +65,7 @@ modelConfig.plots = [(function() {
       });
     });
   }),
-  new PenBundle.Pen('avg-energy', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'avg-energy')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('avg-energy', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Energy Histogram', 'avg-energy')(function() {
         plotManager.resetPen();
@@ -79,12 +77,8 @@ modelConfig.plots = [(function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Energy Histogram', 'init-avg-energy')(function() { Call(procedures.drawVertLine, world.observer.getGlobal("init-avg-energy"));; });
     });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'init-avg-energy')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', undefined)(function() {}); });
-  };
+  }, function() {})];
+  var setup   = function() {};
   var update  = function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Energy Histogram', undefined)(function() {
@@ -97,30 +91,22 @@ modelConfig.plots = [(function() {
 })(), (function() {
   var name    = 'Speed Counts';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'fast')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Counts', 'fast')(function() { plotManager.plotPoint(world.ticker.tickCount(), world.observer.getGlobal("percent-fast"));; });
     });
   }),
-  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'medium')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Counts', 'medium')(function() { plotManager.plotPoint(world.ticker.tickCount(), world.observer.getGlobal("percent-medium"));; });
     });
   }),
-  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'slow')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Counts', 'slow')(function() { plotManager.plotPoint(world.ticker.tickCount(), world.observer.getGlobal("percent-slow"));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', undefined)(function() {}); });
-  };
+  var setup   = function() {};
   var update  = function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Counts', undefined)(function() { plotManager.setYRange(0, 100);; });
@@ -163,9 +149,7 @@ modelConfig.plots = [(function() {
       });
     });
   }),
-  new PenBundle.Pen('avg-speed', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'avg-speed')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('avg-speed', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Histogram', 'avg-speed')(function() {
         plotManager.resetPen();
@@ -177,12 +161,8 @@ modelConfig.plots = [(function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Histogram', 'init-avg-speed')(function() { Call(procedures.drawVertLine, world.observer.getGlobal("init-avg-speed"));; });
     });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'init-avg-speed')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', undefined)(function() {}); });
-  };
+  }, function() {})];
+  var setup   = function() {};
   var update  = function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Speed Histogram', undefined)(function() {

--- a/resources/test/dumps/GasLab Free Gas.js
+++ b/resources/test/dumps/GasLab Free Gas.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GasLabCirc Benchmark.js
+++ b/resources/test/dumps/GasLabCirc Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/GasLabNew Benchmark.js
+++ b/resources/test/dumps/GasLabNew Benchmark.js
@@ -32,127 +32,47 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Pressure vs. Time';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Pressure vs. Time', 'default')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Pressure vs. Time', 'default')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Pressure vs. Time', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Pressure vs. Time', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "pressure", false, 0.0, 20.0, 0.0, 100.0, setup, update);
 })(), (function() {
   var name    = 'Wall Hits per Particle';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Wall Hits per Particle', 'default')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Wall Hits per Particle', 'default')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Wall Hits per Particle', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Wall Hits per Particle', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", false, 0.0, 20.0, 0.0, 1.0, setup, update);
 })(), (function() {
   var name    = 'Energy Histogram';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 10.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'fast')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'fast')(function() {}); });
-  }),
-  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 10.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'medium')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'medium')(function() {}); });
-  }),
-  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 10.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'slow')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'slow')(function() {}); });
-  }),
-  new PenBundle.Pen('avg-energy', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'avg-energy')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'avg-energy')(function() {}); });
-  }),
-  new PenBundle.Pen('init-avg-energy', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'init-avg-energy')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', 'init-avg-energy')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Energy Histogram', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 10.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 10.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 10.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('avg-energy', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('init-avg-energy', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Energy", "Number", true, 0.0, 400.0, 0.0, 10.0, setup, update);
 })(), (function() {
   var name    = 'Speed Counts';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'fast')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'fast')(function() {}); });
-  }),
-  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'medium')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'medium')(function() {}); });
-  }),
-  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'slow')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', 'slow')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Counts', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "count", false, 0.0, 20.0, 0.0, 100.0, setup, update);
 })(), (function() {
   var name    = 'Speed Histogram';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 5.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'fast')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'fast')(function() {}); });
-  }),
-  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 5.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'medium')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'medium')(function() {}); });
-  }),
-  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 5.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'slow')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'slow')(function() {}); });
-  }),
-  new PenBundle.Pen('avg-speed', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'avg-speed')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'avg-speed')(function() {}); });
-  }),
-  new PenBundle.Pen('init-avg-speed', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'init-avg-speed')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', 'init-avg-speed')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Speed Histogram', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('fast', plotOps.makePenOps, false, new PenBundle.State(15.0, 5.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 5.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('slow', plotOps.makePenOps, false, new PenBundle.State(105.0, 5.0, PenBundle.DisplayMode.Bar), function() {}, function() {}),
+  new PenBundle.Pen('avg-speed', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('init-avg-speed', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Speed", "Number", true, 0.0, 50.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "PARTICLES", singular: "particle", varNames: ["speed", "mass", "energy", "wall-hits", "momentum-difference", "last-collision"] }, { name: "FLASHES", singular: "flash", varNames: ["birthday"] }, { name: "CLOCKERS", singular: "clocker", varNames: [] }])([], [])(["number-of-particles", "collide?", "trace?", "init-particle-speed", "particle-mass", "result", "tick-length", "box-edge", "pressure", "pressure-history", "zero-pressure-count", "wall-hits-per-particle", "length-horizontal-surface", "length-vertical-surface", "init-avg-speed", "init-avg-energy", "avg-speed", "avg-energy", "fast", "medium", "slow", "fade-needed?"], ["number-of-particles", "collide?", "trace?", "init-particle-speed", "particle-mass"], [], -50, 50, -50, 50, 4.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/GasLabNew Benchmark.js
+++ b/resources/test/dumps/GasLabNew Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GenDrift P global.js
+++ b/resources/test/dumps/GenDrift P global.js
@@ -32,102 +32,78 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Patch Colors';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color5')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color5')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 5); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color15')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color15')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 15); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color25')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color25')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 25); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color35')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color35')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 35); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color45')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color45')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 45); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color55')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color55')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 55); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color65')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color65')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 65); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color125')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color125')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 125); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color85')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color85')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 85); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color95')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color95')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 95); }).size());;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number", false, 0.0, 100.0, 0.0, 75.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["colors"], ["colors"], [], -28, 28, -28, 28, 8.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/GenDrift P global.js
+++ b/resources/test/dumps/GenDrift P global.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GenDrift P local.js
+++ b/resources/test/dumps/GenDrift P local.js
@@ -32,102 +32,78 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Patch Colors';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color5')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color5')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 5); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color15')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color15')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 15); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color25')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color25')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 25); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color35')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color35')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 35); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color45')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color45')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 45); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color55')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color55')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 55); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color65')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color65')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 65); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color125')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color125')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 125); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color85')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color85')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 85); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', 'color95')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Patch Colors', 'color95')(function() {
         plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 95); }).size());;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Patch Colors', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number", false, 0.0, 100.0, 0.0, 200.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["colors"], ["colors"], [], -30, 30, -30, 30, 6.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/GenDrift P local.js
+++ b/resources/test/dumps/GenDrift P local.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GenDrift T interact.js
+++ b/resources/test/dumps/GenDrift T interact.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GenDrift T interact.js
+++ b/resources/test/dumps/GenDrift T interact.js
@@ -32,90 +32,70 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Turtle Populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color5')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color5')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 5); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color15')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color15')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 15); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color25')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color25')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 25); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color35')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color35')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 35); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color45')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color45')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 45); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color55')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color55')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 55); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color65')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color65')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 65); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color125')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color125')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 75); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color85')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color85')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 85); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color95')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color95')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 95); }).size());;
@@ -127,9 +107,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Turtle Populations', undefined)(function() { plotManager.setYRange(0, world.turtles().size());; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number", false, 0.0, 100.0, 0.0, 70.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["colors", "number", "max-percent"], ["colors", "number"], [], -17, 17, -17, 17, 12.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/GenDrift T reproduce.js
+++ b/resources/test/dumps/GenDrift T reproduce.js
@@ -32,90 +32,70 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Turtle Populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color5')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('color5', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color5')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 5); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color15')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color15', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color15')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 15); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color25')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color25', plotOps.makePenOps, false, new PenBundle.State(25.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color25')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 25); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color35')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color35', plotOps.makePenOps, false, new PenBundle.State(35.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color35')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 35); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color45')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color45', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color45')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 45); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color55')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color55', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color55')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 55); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color65')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color65', plotOps.makePenOps, false, new PenBundle.State(65.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color65')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 65); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color125')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color125', plotOps.makePenOps, false, new PenBundle.State(125.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color125')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 75); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color85')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color85', plotOps.makePenOps, false, new PenBundle.State(85.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color85')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 85); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', 'color95')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('color95', plotOps.makePenOps, false, new PenBundle.State(95.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Turtle Populations', 'color95')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 95); }).size());;
@@ -127,9 +107,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Turtle Populations', undefined)(function() { plotManager.setYRange(0, world.turtles().size());; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Turtle Populations', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number", false, 0.0, 50.0, 0.0, 50.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["colors", "number"], ["colors", "number"], [], -22, 22, -22, 22, 9.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/GenDrift T reproduce.js
+++ b/resources/test/dumps/GenDrift T reproduce.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/GridWalk Benchmark.js
+++ b/resources/test/dumps/GridWalk Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Heatbugs Benchmark.js
+++ b/resources/test/dumps/Heatbugs Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Ising.js
+++ b/resources/test/dumps/Ising.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Magnetization';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('average spin', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Magnetization', 'average spin')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('average spin', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Magnetization', 'average spin')(function() {
         if (Prims.equality(NLMath.mod(world.ticker.tickCount(), world.observer.getGlobal("plotting-interval")), 0)) {
@@ -52,15 +50,9 @@ modelConfig.plots = [(function() {
         plotManager.enableAutoplotting();;
       });
     });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Magnetization', 'axis')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Magnetization', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Magnetization', undefined)(function() {}); });
-  };
+  }, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "average spin", false, 0.0, 20.0, -1.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["temperature", "plotting-interval", "sum-of-spins"], ["temperature", "plotting-interval"], ["spin"], -40, 40, -40, 40, 5.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Ising.js
+++ b/resources/test/dumps/Ising.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Life Turtle-Based.js
+++ b/resources/test/dumps/Life Turtle-Based.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Life.js
+++ b/resources/test/dumps/Life.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Link Breeds Example.js
+++ b/resources/test/dumps/Link Breeds Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Link Lattice Example.js
+++ b/resources/test/dumps/Link Lattice Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Membrane Formation.js
+++ b/resources/test/dumps/Membrane Formation.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Hydrophobic Isolation';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('ratio', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Hydrophobic Isolation', 'ratio')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('ratio', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Hydrophobic Isolation', 'ratio')(function() {
         plotManager.plotValue(ListPrims.mean(world.turtleManager.turtlesOfBreed("OILS").projectionBy(function() {
@@ -43,12 +41,8 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Hydrophobic Isolation', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Hydrophobic Isolation', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", true, 0.0, 10.0, 0.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "WATERS", singular: "water", varNames: [] }, { name: "OILS", singular: "oil", varNames: [] }])([], [])(["num-water", "num-lipids", "water-water-force", "water-oil-force", "too-close-force", "random-force", "lipid-length", "interaction-distance", "too-close-distance"], ["num-water", "num-lipids", "water-water-force", "water-oil-force", "too-close-force", "random-force"], [], -25, 25, -25, 25, 10.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Membrane Formation.js
+++ b/resources/test/dumps/Membrane Formation.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Mousetraps.js
+++ b/resources/test/dumps/Mousetraps.js
@@ -32,36 +32,24 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Traps triggered';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Traps triggered', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Traps triggered', 'default')(function() { plotManager.plotValue(world.observer.getGlobal("traps-triggered"));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Traps triggered', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Traps triggered', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", false, 0.0, 10.0, 0.0, 100.0, setup, update);
 })(), (function() {
   var name    = 'Balls in the air';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Balls in the air', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Balls in the air', 'default')(function() { plotManager.plotValue(world.turtles().size());; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Balls in the air', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Balls in the air', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", false, 0.0, 10.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["max-distance", "traps-triggered"], ["max-distance"], [], -80, 80, -80, 80, 3.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Mousetraps.js
+++ b/resources/test/dumps/Mousetraps.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/PageRank.js
+++ b/resources/test/dumps/PageRank.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Party.js
+++ b/resources/test/dumps/Party.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Number Happy';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('Happy', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Number Happy', 'Happy')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('Happy', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Number Happy', 'Happy')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return SelfPrims.getVariable("happy?"); }).size());;
@@ -46,26 +44,18 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Number Happy', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("number"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Number Happy', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "clock", "", false, 0.0, 10.0, 0.0, 150.0, setup, update);
 })(), (function() {
   var name    = 'Single Sex Groups';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('Single Sex', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Single Sex Groups', 'Single Sex')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('Single Sex', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Single Sex Groups', 'Single Sex')(function() { plotManager.plotValue(world.observer.getGlobal("boring-groups"));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Single Sex Groups', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Single Sex Groups', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "clock", "", false, 0.0, 10.0, 0.0, 12.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["happy?", "my-group-site"], [])(["tolerance", "number", "num-groups", "group-sites", "boring-groups"], ["tolerance", "number", "num-groups"], [], -80, 1, -55, 55, 5.0, true, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Party.js
+++ b/resources/test/dumps/Party.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Patch Coordinates Example.js
+++ b/resources/test/dumps/Patch Coordinates Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Peppered Moths.js
+++ b/resources/test/dumps/Peppered Moths.js
@@ -32,30 +32,22 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Moth Colors Over Time';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('Light', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Moth Colors Over Time', 'Light')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('Light', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Moth Colors Over Time', 'Light')(function() { plotManager.plotValue(world.observer.getGlobal("light-moths"));; });
     });
   }),
-  new PenBundle.Pen('Medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Moth Colors Over Time', 'Medium')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('Medium', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Moth Colors Over Time', 'Medium')(function() { plotManager.plotValue(world.observer.getGlobal("medium-moths"));; });
     });
   }),
-  new PenBundle.Pen('Dark', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Moth Colors Over Time', 'Dark')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('Dark', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Moth Colors Over Time', 'Dark')(function() { plotManager.plotValue(world.observer.getGlobal("dark-moths"));; });
     });
   }),
-  new PenBundle.Pen('Pollution', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Moth Colors Over Time', 'Pollution')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('Pollution', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Moth Colors Over Time', 'Pollution')(function() {
         plotManager.plotValue((((Call(procedures.upperBound) / 3) * world.observer.getGlobal("darkness")) / 8));;
@@ -67,9 +59,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Moth Colors Over Time', undefined)(function() { plotManager.setYRange(0, Call(procedures.upperBound));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Moth Colors Over Time', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Moth Color Count", true, 0.0, 100.0, 0.0, 200.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "MOTHS", singular: "moth", varNames: ["age"] }])([], [])(["num-moths", "mutation", "selection", "speed", "cycle-pollution?", "light-moths", "medium-moths", "dark-moths", "darkness", "darkening?"], ["num-moths", "mutation", "selection", "speed", "cycle-pollution?"], [], -16, 16, -20, 20, 10.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Peppered Moths.js
+++ b/resources/test/dumps/Peppered Moths.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Preferential Attachment.js
+++ b/resources/test/dumps/Preferential Attachment.js
@@ -32,9 +32,7 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Degree Distribution (log-log)';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Point), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution (log-log)', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Point), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Degree Distribution (log-log)', 'default')(function() {
         if (!world.observer.getGlobal("plot?")) {
@@ -53,19 +51,13 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution (log-log)', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution (log-log)', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "log(degree)", "log(# of nodes)", false, 0.0, 0.3, 0.0, 0.3, setup, update);
 })(), (function() {
   var name    = 'Degree Distribution';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Bar), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Degree Distribution', 'default')(function() {
         if (!world.observer.getGlobal("plot?")) {
@@ -78,12 +70,8 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Degree Distribution', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "degree", "# of nodes", false, 1.0, 10.0, 0.0, 10.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["plot?", "layout?"], ["plot?", "layout?"], [], -45, 45, -45, 45, 5.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Preferential Attachment.js
+++ b/resources/test/dumps/Preferential Attachment.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Rabbits Grass Weeds.js
+++ b/resources/test/dumps/Rabbits Grass Weeds.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Rabbits Grass Weeds.js
+++ b/resources/test/dumps/Rabbits Grass Weeds.js
@@ -32,25 +32,19 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('grass', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'grass')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('grass', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'grass')(function() {
         plotManager.plotValue((world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 55); }).size() / 4));;
       });
     });
   }),
-  new PenBundle.Pen('rabbits', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'rabbits')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('rabbits', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'rabbits')(function() { plotManager.plotValue(world.turtleManager.turtlesOfBreed("RABBITS").size());; });
     });
   }),
-  new PenBundle.Pen('weeds', plotOps.makePenOps, false, new PenBundle.State(115.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'weeds')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('weeds', plotOps.makePenOps, false, new PenBundle.State(115.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'weeds')(function() {
         plotManager.plotValue((world.patches().agentFilter(function() { return Prims.equality(SelfPrims.getPatchVariable("pcolor"), 115); }).size() / 4));;
@@ -62,9 +56,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Populations', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("number"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Pop", true, 0.0, 100.0, 0.0, 111.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "RABBITS", singular: "rabbit", varNames: ["energy"] }])([], [])(["grass-grow-rate", "weeds-grow-rate", "grass-energy", "weed-energy", "number", "birth-threshold"], ["grass-grow-rate", "weeds-grow-rate", "grass-energy", "weed-energy", "number", "birth-threshold"], [], -20, 20, -20, 20, 12.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Random Basic.js
+++ b/resources/test/dumps/Random Basic.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Reactor X-Section.js
+++ b/resources/test/dumps/Reactor X-Section.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Reactor X-Section.js
+++ b/resources/test/dumps/Reactor X-Section.js
@@ -32,16 +32,12 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Power';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('power-rated', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Power', 'power-rated')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('power-rated', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Power', 'power-rated')(function() { plotManager.plotValue(world.observer.getGlobal("power-rated"));; });
     });
   }),
-  new PenBundle.Pen('avg-power', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Power', 'avg-power')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('avg-power', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Power', 'avg-power')(function() { plotManager.plotValue(world.observer.getGlobal("average-power"));; });
     });
@@ -51,9 +47,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Power', undefined)(function() { plotManager.setYRange(0, (3 * world.observer.getGlobal("power-rated")));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Power', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "power", false, 0.0, 250.0, 0.0, 105.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["power-rated", "reactor-size", "rod-depth", "rod-spacing", "spend-fuel?", "power", "old-power", "old-power-2", "old-power-3", "old-power-4", "average-power", "power-change", "rod-length", "n-rods", "r"], ["power-rated", "reactor-size", "rod-depth", "rod-spacing", "spend-fuel?"], ["x", "y", "rod?"], -70, 70, -70, 70, 3.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Rope.js
+++ b/resources/test/dumps/Rope.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Rugby.js
+++ b/resources/test/dumps/Rugby.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Sandpile.js
+++ b/resources/test/dumps/Sandpile.js
@@ -32,26 +32,18 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Average grain count';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('average', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average grain count', 'average')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('average', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average grain count', 'average')(function() { plotManager.plotValue((world.observer.getGlobal("total") / world.patches().size()));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average grain count', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average grain count', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "ticks", "grains", false, 0.0, 1.0, 2.0, 2.1, setup, update);
 })(), (function() {
   var name    = 'Avalanche sizes';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche sizes', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Avalanche sizes', 'default')(function() {
         if ((Prims.equality(NLMath.mod(world.ticker.tickCount(), 100), 0) && !ListPrims.empty(world.observer.getGlobal("sizes")))) {
@@ -77,19 +69,13 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche sizes', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche sizes', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "log size", "log count", false, 0.0, 1.0, 0.0, 1.0, setup, update);
 })(), (function() {
   var name    = 'Avalanche lifetimes';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche lifetimes', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Avalanche lifetimes', 'default')(function() {
         if ((Prims.equality(NLMath.mod(world.ticker.tickCount(), 100), 0) && !ListPrims.empty(world.observer.getGlobal("lifetimes")))) {
@@ -115,12 +101,8 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche lifetimes', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Avalanche lifetimes', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "log lifetime", "log count", false, 0.0, 1.0, 0.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])(["animate-avalanches?", "drop-location", "grains-per-patch", "total", "total-on-tick", "sizes", "last-size", "lifetimes", "last-lifetime", "selected-patch", "default-color", "fired-color", "selected-color"], ["animate-avalanches?", "drop-location", "grains-per-patch"], ["n", "n-stack", "base-color"], -50, 50, -50, 50, 4.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Sandpile.js
+++ b/resources/test/dumps/Sandpile.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Segregation.js
+++ b/resources/test/dumps/Segregation.js
@@ -32,38 +32,26 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Percent Similar';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('percent', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Percent Similar', 'percent')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('percent', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Percent Similar', 'percent')(function() { plotManager.plotValue(world.observer.getGlobal("percent-similar"));; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Percent Similar', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Percent Similar', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "%", false, 0.0, 5.0, 0.0, 100.0, setup, update);
 })(), (function() {
   var name    = 'Number-unhappy';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(64.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Number-unhappy', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(64.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Number-unhappy', 'default')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return !SelfPrims.getVariable("happy?"); }).size());;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Number-unhappy', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Number-unhappy', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "", "", false, 0.0, 10.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["happy?", "similar-nearby", "other-nearby", "total-nearby"], [])(["%-similar-wanted", "visualization", "density", "percent-similar", "percent-unhappy"], ["%-similar-wanted", "visualization", "density"], [], -25, 25, -25, 25, 8.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Segregation.js
+++ b/resources/test/dumps/Segregation.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Slime.js
+++ b/resources/test/dumps/Slime.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/State Machine Example.js
+++ b/resources/test/dumps/State Machine Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Team Assembly.js
+++ b/resources/test/dumps/Team Assembly.js
@@ -32,29 +32,11 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Link counts';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('newcomer-newcomer', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'newcomer-newcomer')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'newcomer-newcomer')(function() {}); });
-  }),
-  new PenBundle.Pen('newcomer-incumbent', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'newcomer-incumbent')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'newcomer-incumbent')(function() {}); });
-  }),
-  new PenBundle.Pen('incumbent-incumbent', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'incumbent-incumbent')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'incumbent-incumbent')(function() {}); });
-  }),
-  new PenBundle.Pen('previous collaborators', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'previous collaborators')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', 'previous collaborators')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Link counts', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('newcomer-newcomer', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('newcomer-incumbent', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('incumbent-incumbent', plotOps.makePenOps, false, new PenBundle.State(45.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('previous collaborators', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
   var update  = function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Link counts', undefined)(function() {
@@ -90,40 +72,28 @@ modelConfig.plots = [(function() {
 })(), (function() {
   var name    = '% of agents in the giant component';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('% of agents in the giant component', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('% of agents in the giant component', 'default')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), (world.observer.getGlobal("giant-component-size") / world.turtles().size()));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('% of agents in the giant component', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('% of agents in the giant component', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "% of all agents", false, 0.0, 10.0, 0.0, 1.0, setup, update);
 })(), (function() {
   var name    = 'Average component size';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average component size', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average component size', 'default')(function() {
         plotManager.plotPoint(world.ticker.tickCount(), ListPrims.mean(world.observer.getGlobal("components")));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average component size', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average component size', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Number of agents", false, 0.0, 10.0, 0.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["incumbent?", "in-team?", "downtime", "explored?"], ["new-collaboration?"])(["layout?", "p", "q", "team-size", "plot?", "max-downtime", "newcomer", "component-size", "giant-component-size", "components"], ["layout?", "p", "q", "team-size", "plot?", "max-downtime"], [], -50, 50, -50, 50, 4.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Team Assembly.js
+++ b/resources/test/dumps/Team Assembly.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Tie System Example.js
+++ b/resources/test/dumps/Tie System Example.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Traffic Basic.js
+++ b/resources/test/dumps/Traffic Basic.js
@@ -32,39 +32,29 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Car speeds';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('red car', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Car speeds', 'red car')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('red car', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Car speeds', 'red car')(function() {
         plotManager.plotValue(world.observer.getGlobal("sample-car").projectionBy(function() { return SelfPrims.getVariable("speed"); }));;
       });
     });
   }),
-  new PenBundle.Pen('min speed', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Car speeds', 'min speed')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('min speed', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Car speeds', 'min speed')(function() {
         plotManager.plotValue(ListPrims.min(world.turtles().projectionBy(function() { return SelfPrims.getVariable("speed"); })));;
       });
     });
   }),
-  new PenBundle.Pen('max speed', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Car speeds', 'max speed')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('max speed', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Car speeds', 'max speed')(function() {
         plotManager.plotValue(ListPrims.max(world.turtles().projectionBy(function() { return SelfPrims.getVariable("speed"); })));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Car speeds', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Car speeds', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "speed", true, 0.0, 300.0, 0.0, 1.1, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["speed", "speed-limit", "speed-min"], [])(["number-of-cars", "deceleration", "acceleration", "sample-car"], ["number-of-cars", "deceleration", "acceleration"], [], -25, 25, -4, 4, 13.0, true, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Traffic Basic.js
+++ b/resources/test/dumps/Traffic Basic.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Traffic Grid.js
+++ b/resources/test/dumps/Traffic Grid.js
@@ -32,28 +32,20 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Average Wait Time of Cars';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Wait Time of Cars', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average Wait Time of Cars', 'default')(function() {
         plotManager.plotValue(ListPrims.mean(world.turtles().projectionBy(function() { return SelfPrims.getVariable("wait-time"); })));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Wait Time of Cars', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Wait Time of Cars', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Average Wait", false, 0.0, 100.0, 0.0, 5.0, setup, update);
 })(), (function() {
   var name    = 'Average Speed of Cars';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Speed of Cars', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Average Speed of Cars', 'default')(function() {
         plotManager.plotValue(ListPrims.mean(world.turtles().projectionBy(function() { return SelfPrims.getVariable("speed"); })));;
@@ -65,16 +57,12 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Average Speed of Cars', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("speed-limit"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Average Speed of Cars', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Average Speed", false, 0.0, 100.0, 0.0, 1.0, setup, update);
 })(), (function() {
   var name    = 'Stopped Cars';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Stopped Cars', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(0.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Stopped Cars', 'default')(function() { plotManager.plotValue(world.observer.getGlobal("num-cars-stopped"));; });
     });
@@ -84,9 +72,7 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Stopped Cars', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("num-cars"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Stopped Cars', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Stopped Cars", false, 0.0, 100.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["speed", "up-car?", "wait-time"], [])(["grid-size-y", "grid-size-x", "power?", "num-cars", "speed-limit", "ticks-per-cycle", "current-phase", "current-auto?", "grid-x-inc", "grid-y-inc", "acceleration", "phase", "num-cars-stopped", "current-light", "intersections", "roads"], ["grid-size-y", "grid-size-x", "power?", "num-cars", "speed-limit", "ticks-per-cycle", "current-phase", "current-auto?"], ["intersection?", "green-light-up?", "my-row", "my-column", "my-phase", "auto?"], -18, 18, -18, 18, 9.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Traffic Grid.js
+++ b/resources/test/dumps/Traffic Grid.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Tree Simple.js
+++ b/resources/test/dumps/Tree Simple.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Vants.js
+++ b/resources/test/dumps/Vants.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Virus on a Network.js
+++ b/resources/test/dumps/Virus on a Network.js
@@ -32,39 +32,29 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Network Status';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('susceptible', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Network Status', 'susceptible')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('susceptible', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Network Status', 'susceptible')(function() {
         plotManager.plotValue(((world.turtles().agentFilter(function() { return (!SelfPrims.getVariable("infected?") && !SelfPrims.getVariable("resistant?")); }).size() / world.turtles().size()) * 100));;
       });
     });
   }),
-  new PenBundle.Pen('infected', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Network Status', 'infected')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('infected', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Network Status', 'infected')(function() {
         plotManager.plotValue(((world.turtles().agentFilter(function() { return SelfPrims.getVariable("infected?"); }).size() / world.turtles().size()) * 100));;
       });
     });
   }),
-  new PenBundle.Pen('resistant', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Network Status', 'resistant')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('resistant', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Network Status', 'resistant')(function() {
         plotManager.plotValue(((world.turtles().agentFilter(function() { return SelfPrims.getVariable("resistant?"); }).size() / world.turtles().size()) * 100));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Network Status', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Network Status', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "% of nodes", true, 0.0, 52.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["infected?", "resistant?", "virus-check-timer"], [])(["gain-resistance-chance", "recovery-chance", "virus-spread-chance", "number-of-nodes", "virus-check-frequency", "initial-outbreak-size", "average-node-degree"], ["gain-resistance-chance", "recovery-chance", "virus-spread-chance", "number-of-nodes", "virus-check-frequency", "initial-outbreak-size", "average-node-degree"], [], -20, 20, -20, 20, 11.0, false, false, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Virus on a Network.js
+++ b/resources/test/dumps/Virus on a Network.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Virus.js
+++ b/resources/test/dumps/Virus.js
@@ -32,46 +32,34 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('sick', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'sick')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('sick', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'sick')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return SelfPrims.getVariable("sick?"); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('immune', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'immune')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('immune', plotOps.makePenOps, false, new PenBundle.State(5.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'immune')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Call(procedures.immune_p); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('healthy', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'healthy')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('healthy', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'healthy')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return (!SelfPrims.getVariable("sick?") && !Call(procedures.immune_p)); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('total', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', 'total')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('total', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Populations', 'total')(function() { plotManager.plotValue(world.turtles().size());; });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Populations', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "weeks", "people", true, 0.0, 52.0, 0.0, 200.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["sick?", "remaining-immunity", "sick-time", "age"], [])(["duration", "chance-recover", "infectiousness", "number-people", "turtle-shape", "%infected", "%immune", "lifespan", "chance-reproduce", "carrying-capacity", "immunity-duration"], ["duration", "chance-recover", "infectiousness", "number-people", "turtle-shape"], [], -17, 17, -17, 17, 14.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Virus.js
+++ b/resources/test/dumps/Virus.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Voting.js
+++ b/resources/test/dumps/Voting.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [];

--- a/resources/test/dumps/Wealth Distribution.js
+++ b/resources/test/dumps/Wealth Distribution.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Wealth Distribution.js
+++ b/resources/test/dumps/Wealth Distribution.js
@@ -32,27 +32,21 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'Class Plot';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('low', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Plot', 'low')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('low', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Class Plot', 'low')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 15); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('mid', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Plot', 'mid')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('mid', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Class Plot', 'mid')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 55); }).size());;
       });
     });
   }),
-  new PenBundle.Pen('up', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Plot', 'up')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('up', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Class Plot', 'up')(function() {
         plotManager.plotValue(world.turtles().agentFilter(function() { return Prims.equality(SelfPrims.getVariable("color"), 105); }).size());;
@@ -64,16 +58,12 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Class Plot', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("num-people"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Plot', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Turtles", true, 0.0, 50.0, 0.0, 250.0, setup, update);
 })(), (function() {
   var name    = 'Class Histogram';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Bar), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Histogram', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Bar), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Class Histogram', 'default')(function() {
         plotManager.resetPen();
@@ -91,16 +81,12 @@ modelConfig.plots = [(function() {
       plotManager.withTemporaryContext('Class Histogram', undefined)(function() { plotManager.setYRange(0, world.observer.getGlobal("num-people"));; });
     });
   };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Class Histogram', undefined)(function() {}); });
-  };
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Classes", "Turtles", false, 0.0, 3.0, 0.0, 250.0, setup, update);
 })(), (function() {
   var name    = 'Lorenz Curve';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('lorenz', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Lorenz Curve', 'lorenz')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('lorenz', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Lorenz Curve', 'lorenz')(function() {
         plotManager.resetPen();
@@ -120,34 +106,22 @@ modelConfig.plots = [(function() {
         plotManager.plotValue(100);;
       });
     });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Lorenz Curve', 'equal')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Lorenz Curve', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Lorenz Curve', undefined)(function() {}); });
-  };
+  }, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Pop %", "Wealth %", true, 0.0, 100.0, 0.0, 100.0, setup, update);
 })(), (function() {
   var name    = 'Gini-Index v. Time';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Gini-Index v. Time', 'default')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('Gini-Index v. Time', 'default')(function() {
         plotManager.plotValue(((world.observer.getGlobal("gini-index-reserve") / world.observer.getGlobal("num-people")) / 0.5));;
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Gini-Index v. Time', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('Gini-Index v. Time', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "Time", "Gini", false, 0.0, 50.0, 0.0, 1.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([])(["age", "wealth", "life-expectancy", "metabolism", "vision"], [])(["max-vision", "grain-growth-interval", "metabolism-max", "num-people", "percent-best-land", "life-expectancy-max", "num-grain-grown", "life-expectancy-min", "max-grain", "gini-index-reserve", "lorenz-points"], ["max-vision", "grain-growth-interval", "metabolism-max", "num-people", "percent-best-land", "life-expectancy-max", "num-grain-grown", "life-expectancy-min"], ["grain-here", "max-grain-here"], -25, 25, -25, 25, 8.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Wolf Benchmark.js
+++ b/resources/test/dumps/Wolf Benchmark.js
@@ -32,27 +32,11 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('sheep', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'sheep')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'sheep')(function() {}); });
-  }),
-  new PenBundle.Pen('wolves', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'wolves')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'wolves')(function() {}); });
-  }),
-  new PenBundle.Pen('grass / 4', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'grass / 4')(function() {}); });
-  }, function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'grass / 4')(function() {}); });
-  })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', undefined)(function() {}); });
-  };
+  var pens    = [new PenBundle.Pen('sheep', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('wolves', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {}),
+  new PenBundle.Pen('grass / 4', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {})];
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "pop.", false, 0.0, 100.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "SHEEP", singular: "a-sheep", varNames: [] }, { name: "WOLVES", singular: "wolf", varNames: [] }])(["energy", "prey"], [])(["init-sheep", "sheep-metabolism", "sheep-reproduce", "init-wolves", "wolf-metabolism", "wolf-reproduce", "grass?", "grass-delay", "plot?", "result"], ["init-sheep", "sheep-metabolism", "sheep-reproduce", "init-wolves", "wolf-metabolism", "wolf-reproduce", "grass?", "grass-delay", "plot?"], ["countdown"], -20, 20, -20, 20, 8.0, true, true, turtleShapes, linkShapes, function(){});

--- a/resources/test/dumps/Wolf Benchmark.js
+++ b/resources/test/dumps/Wolf Benchmark.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Wolf Sheep Predation.js
+++ b/resources/test/dumps/Wolf Sheep Predation.js
@@ -26,7 +26,8 @@ var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.pl
 if (typeof javax !== "undefined") {
   modelConfig.output = {
     clear: function() {},
-    write: function(str) { context.getWriter().print(str); }
+    write: function(str) { context.getWriter().print(str); },
+    alert: function(str) {}
   }
 }
 modelConfig.plots = [(function() {

--- a/resources/test/dumps/Wolf Sheep Predation.js
+++ b/resources/test/dumps/Wolf Sheep Predation.js
@@ -32,23 +32,17 @@ if (typeof javax !== "undefined") {
 modelConfig.plots = [(function() {
   var name    = 'populations';
   var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
-  var pens    = [new PenBundle.Pen('sheep', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'sheep')(function() {}); });
-  }, function() {
+  var pens    = [new PenBundle.Pen('sheep', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('populations', 'sheep')(function() { plotManager.plotValue(world.turtleManager.turtlesOfBreed("SHEEP").size());; });
     });
   }),
-  new PenBundle.Pen('wolves', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'wolves')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('wolves', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('populations', 'wolves')(function() { plotManager.plotValue(world.turtleManager.turtlesOfBreed("WOLVES").size());; });
     });
   }),
-  new PenBundle.Pen('grass / 4', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', 'grass / 4')(function() {}); });
-  }, function() {
+  new PenBundle.Pen('grass / 4', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
     workspace.rng.withAux(function() {
       plotManager.withTemporaryContext('populations', 'grass / 4')(function() {
         if (world.observer.getGlobal("grass?")) {
@@ -57,12 +51,8 @@ modelConfig.plots = [(function() {
       });
     });
   })];
-  var setup   = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', undefined)(function() {}); });
-  };
-  var update  = function() {
-    workspace.rng.withAux(function() { plotManager.withTemporaryContext('populations', undefined)(function() {}); });
-  };
+  var setup   = function() {};
+  var update  = function() {};
   return new Plot(name, pens, plotOps, "time", "pop.", true, 0.0, 100.0, 0.0, 100.0, setup, update);
 })()];
 var workspace = tortoise_require('engine/workspace')(modelConfig)([{ name: "SHEEP", singular: "a-sheep", varNames: [] }, { name: "WOLVES", singular: "wolf", varNames: [] }])(["energy"], [])(["initial-number-sheep", "sheep-gain-from-food", "sheep-reproduce", "initial-number-wolves", "wolf-gain-from-food", "wolf-reproduce", "grass?", "grass-regrowth-time", "show-energy?", "grass"], ["initial-number-sheep", "sheep-gain-from-food", "sheep-reproduce", "initial-number-wolves", "wolf-gain-from-food", "wolf-reproduce", "grass?", "grass-regrowth-time", "show-energy?"], ["countdown"], -25, 25, -25, 25, 9.0, true, true, turtleShapes, linkShapes, function(){});

--- a/tortoise/src/main/scala/WidgetCompiler.scala
+++ b/tortoise/src/main/scala/WidgetCompiler.scala
@@ -17,6 +17,9 @@ import
   org.nlogo.core.{ Button, CompilerException, Monitor, Pen, Plot, Slider, Token, Widget }
 
 import
+  scalaz.Scalaz.ToValidationOps
+
+import
   TortoiseSymbol.JsDeclare
 
 import
@@ -91,9 +94,12 @@ class WidgetCompiler(compileCommand:  String => CompiledStringV,
     val penName       = penNameOpt map (name => s"'$name'") getOrElse "undefined"
     val inTempContext = (f: String) => s"plotManager.withTemporaryContext('$plotNameRaw', $penName)($f)"
     val withAuxRNG    = (f: String) => s"workspace.rng.withAux($f)"
-    compileCommand(code) map thunkifyProcedure map
-      (inTempContext andThen thunkifyProcedure) map
-      (withAuxRNG    andThen thunkifyProcedure)
+    if (code.trim.isEmpty)
+      thunkifyProcedure("").successNel
+    else
+      compileCommand(code) map thunkifyProcedure map
+        (inTempContext andThen thunkifyProcedure) map
+        (withAuxRNG    andThen thunkifyProcedure)
   }
 }
 


### PR DESCRIPTION
* Pulls problems with widgets up into `compilation.{success,messages}`, for easier access in Galapagos. This will require Galapagos checking code to use these new keys.
* Uses `modelConfig.output.alert("alert message here")` to notify of errors within plots and pens. Fails gracefully where possible (eg. a bad pen will not wreck the plot that contains it). This change will require providing `modelConfig.output.alert` in Galapagos.
* Empty plot and pen methods are compiled to `function() {}` instead of the longer function with context nesting. This is done as a single commit in case it is not desired, and required 3 lines of change [here](https://github.com/NetLogo/Tortoise/compare/master...wip-improved-plot-errors#diff-f322a9e46d1d6766f785421b5bcd3894R132). The reason I would favor making this change is that it makes some source dumps, [this one](https://github.com/NetLogo/Tortoise/compare/master...wip-improved-plot-errors#diff-69d765a7edc99b854b9920ef3cf9a0c0L35) for instance, much easier to audit for changes.