### PR TITLE
Wip lower memory usage

### DIFF
--- a/jvm/src/main/coffee/engine/core/link/linkvariables.coffee
+++ b/jvm/src/main/coffee/engine/core/link/linkvariables.coffee
@@ -1,0 +1,126 @@
+# (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+ColorModel = require('engine/core/colormodel')
+NLType     = require('../typechecker')
+
+{ ImmutableVariableSpec, MutableVariableSpec } = require('../structure/variablespec')
+
+# (String) => Unit
+setShape = (shape) ->
+  @_shape = shape.toLowerCase()
+  @_genVarUpdate("shape")
+  return
+
+# (AbstractAgentSet|Breed|String) => Unit
+setBreed = (breed) ->
+
+  type = NLType(breed)
+
+  trueBreed =
+    if type.isString()
+      @world.breedManager.get(breed)
+    else if type.isAgentSet()
+      specialName = breed.getSpecialName()
+      if specialName?
+        @world.breedManager.get(specialName)
+      else
+        throw new Error("You can't set BREED to a non-breed agentset.")
+    else
+      breed
+
+  if @_breed isnt trueBreed
+    trueBreed.add(this)
+    @_breed?.remove(this)
+
+    newNames = @_varNamesForBreed(trueBreed)
+    oldNames = @_varNamesForBreed(@_breed)
+    @_varManager.refineBy(oldNames, newNames)
+
+  @_breed = trueBreed
+  @_genVarUpdate("breed")
+
+  setShape.call(this, trueBreed.getShape())
+
+  if trueBreed isnt @world.breedManager.links()
+    @world.breedManager.links().add(this)
+
+  return
+
+# (Number) => Unit
+setColor = (color) ->
+  @_color = ColorModel.wrapColor(color)
+  @_genVarUpdate("color")
+  return
+
+# (Turtle) => Unit
+setEnd1 = (turtle) ->
+  @end1 = turtle
+  @_genVarUpdate("end1")
+  return
+
+# (Turtle) => Unit
+setEnd2 = (turtle) ->
+  @end2 = turtle
+  @_genVarUpdate("end2")
+  return
+
+# (Boolean) => Unit
+setIsHidden = (isHidden) ->
+  @_isHidden = isHidden
+  @_genVarUpdate("hidden?")
+  return
+
+# (String) => Unit
+setLabel = (label) ->
+  @_label = label
+  @_genVarUpdate("label")
+  return
+
+# (Number) => Unit
+setLabelColor = (color) ->
+  @_labelcolor = ColorModel.wrapColor(color)
+  @_genVarUpdate("label-color")
+  return
+
+# (Number) => Unit
+setThickness = (thickness) ->
+  @_thickness = thickness
+  @_genVarUpdate("thickness")
+  return
+
+# (String) => Unit
+setTieMode = (mode) ->
+  @tiemode = mode
+  @_genVarUpdate("tie-mode")
+  return
+
+Setters = {
+  setBreed
+  setColor
+  setEnd1
+  setEnd2
+  setIsHidden
+  setLabel
+  setLabelColor
+  setShape
+  setThickness
+  setTieMode
+}
+
+VariableSpecs = [
+  new MutableVariableSpec('breed',       (-> @_getLinksByBreedName(@_breed.name)), setBreed)
+, new MutableVariableSpec('color',       (-> @_color),                             setColor)
+, new MutableVariableSpec('end1',        (-> @end1),                               setEnd1)
+, new MutableVariableSpec('end2',        (-> @end2),                               setEnd2)
+, new MutableVariableSpec('hidden?',     (-> @_isHidden),                          setIsHidden)
+, new MutableVariableSpec('label',       (-> @_label),                             setLabel)
+, new MutableVariableSpec('label-color', (-> @_labelcolor),                        setLabelColor)
+, new MutableVariableSpec('shape',       (-> @_shape),                             setShape)
+, new MutableVariableSpec('thickness',   (-> @_thickness),                         setThickness)
+, new MutableVariableSpec('tie-mode',    (-> @tiemode),                            setTieMode)
+]
+
+module.exports = {
+  Setters
+  VariableSpecs
+}

--- a/jvm/src/main/coffee/engine/core/observer.coffee
+++ b/jvm/src/main/coffee/engine/core/observer.coffee
@@ -12,6 +12,8 @@ Nobody          = require('./nobody')
 NLType          = require('./typechecker')
 VariableManager = require('./structure/variablemanager')
 
+{ ExtraVariableSpec } = require('./structure/variablespec')
+
 module.exports =
   class Observer
 
@@ -32,8 +34,9 @@ module.exports =
 
       @resetPerspective()
 
-      @_varManager      = new VariableManager(@_globalNames)
-      @_codeGlobalNames = _(@_globalNames).difference(@_interfaceGlobalNames)
+      globalSpecs       = @_globalNames.map((name) -> new ExtraVariableSpec(name))
+      @_varManager      = new VariableManager(this, globalSpecs)
+      @_codeGlobalNames = _(@_globalNames).difference(@_interfaceGlobalNames).value()
 
     # () => Unit
     clearCodeGlobals: ->

--- a/jvm/src/main/coffee/engine/core/patch.coffee
+++ b/jvm/src/main/coffee/engine/core/patch.coffee
@@ -13,15 +13,13 @@ Comparator      = require('util/comparator')
 module.exports =
   class Patch
 
-    _updateVarsByName: undefined # (String*) => Unit
     _varManager:       undefined # VariableManager
 
     _turtles: undefined # Array[Turtle]
 
     # (Number, Number, Number, World, (Updatable) => (String*) => Unit, () => Unit, () => Unit, () => Unit, (String) => LinkSet, Number, String, Number) => Patch
-    constructor: (@id, @pxcor, @pycor, @world, genUpdate, @_declareNonBlackPatch, @_decrementPatchLabelCount
+    constructor: (@id, @pxcor, @pycor, @world, @_genUpdate, @_declareNonBlackPatch, @_decrementPatchLabelCount
                 , @_incrementPatchLabelCount, @_pcolor = 0.0, @_plabel = "", @_plabelcolor = 9.9) ->
-      @_updateVarsByName = genUpdate(this)
       @_turtles          = []
       @_varManager       = @_genVarManager(@world.patchesOwnNames)
 
@@ -154,5 +152,5 @@ module.exports =
 
     # (String) => Unit
     _genVarUpdate: (varName) ->
-      @_updateVarsByName(varName)
+      @_genUpdate(this)(varName)
       return

--- a/jvm/src/main/coffee/engine/core/patch/patchvariables.coffee
+++ b/jvm/src/main/coffee/engine/core/patch/patchvariables.coffee
@@ -1,0 +1,56 @@
+# (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+ColorModel = require('engine/core/colormodel')
+
+{ ImmutableVariableSpec, MutableVariableSpec } = require('../structure/variablespec')
+
+# (Number) => Unit
+setPcolor = (color) ->
+  wrappedColor = ColorModel.wrapColor(color)
+  if @_pcolor isnt wrappedColor
+    @_pcolor = wrappedColor
+    @_genVarUpdate("pcolor")
+    if wrappedColor isnt 0
+      @_declareNonBlackPatch()
+  return
+
+# (String) => Unit
+setPlabel = (label) ->
+  wasEmpty = @_plabel is ""
+  isEmpty  = label is ""
+
+  @_plabel = label
+  @_genVarUpdate("plabel")
+
+  if isEmpty and not wasEmpty
+    @_decrementPatchLabelCount()
+  else if not isEmpty and wasEmpty
+    @_incrementPatchLabelCount()
+
+  return
+
+# (Number) => Unit
+setPlabelColor = (color) ->
+  @_plabelcolor = ColorModel.wrapColor(color)
+  @_genVarUpdate("plabel-color")
+  return
+
+Setters = {
+  setPcolor
+  setPlabel
+  setPlabelColor
+}
+
+VariableSpecs = [
+  new ImmutableVariableSpec('id',    -> @id)
+, new ImmutableVariableSpec('pxcor', -> @pxcor)
+, new ImmutableVariableSpec('pycor', -> @pycor)
+, new MutableVariableSpec('pcolor',       (-> @_pcolor),      setPcolor)
+, new MutableVariableSpec('plabel',       (-> @_plabel),      setPlabel)
+, new MutableVariableSpec('plabel-color', (-> @_plabelcolor), setPlabelColor)
+]
+
+module.exports = {
+  Setters
+  VariableSpecs
+}

--- a/jvm/src/main/coffee/engine/core/structure/variablespec.coffee
+++ b/jvm/src/main/coffee/engine/core/structure/variablespec.coffee
@@ -1,0 +1,24 @@
+# (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+class VariableSpec
+  # (String) => VariableSpec[T]
+  constructor: (@name) ->
+
+class ExtraVariableSpec extends VariableSpec
+
+class ImmutableVariableSpec extends VariableSpec
+  # (String, () => T) => ImmutableVariableSpec[T]
+  constructor: (name, @get) ->
+    super(name)
+
+class MutableVariableSpec extends VariableSpec
+  #(String, () => T, (T) => Unit) => MutableVariableSpec[T]
+  constructor: (name, @get, @set) ->
+    super(name)
+
+module.exports = {
+  ExtraVariableSpec
+  ImmutableVariableSpec
+  MutableVariableSpec
+  VariableSpec
+}

--- a/jvm/src/main/coffee/engine/core/turtle/turtlevariables.coffee
+++ b/jvm/src/main/coffee/engine/core/turtle/turtlevariables.coffee
@@ -1,0 +1,213 @@
+# (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+ColorModel = require('engine/core/colormodel')
+NLType     = require('../typechecker')
+StrictMath = require('shim/strictmath')
+NLMath     = require('util/nlmath')
+
+{ ImmutableVariableSpec, MutableVariableSpec } = require('../structure/variablespec')
+
+###
+ "Jason, this is craziness!", you say.  "Not quite," I say.  It _is_ kind of lame, but changing turtle members
+ needs to be controlled, so that all changes cause updates to be triggered.  And since the `VariableManager` needs
+ to know how to set all of the variables, we may as well declare the code for that in a place where it can be
+ easily reused. --JAB (6/2/14, 8/28/15)
+###
+
+# (Number, Turtle) => Unit
+setXcor = (newX, tiedCaller = undefined) ->
+
+  originPatch = @getPatchHere()
+  oldX        = @xcor
+  @xcor       = @world.topology.wrapX(newX)
+  @_updateVarsByName("xcor")
+  @_drawLine(oldX, @ycor, newX, @ycor)
+
+  if originPatch isnt @getPatchHere()
+    originPatch.untrackTurtle(this)
+    @getPatchHere().trackTurtle(this)
+
+  @linkManager._refresh()
+
+  dx = @xcor - oldX
+  @_tiedTurtles().forEach(
+    (turtle) =>
+      if turtle isnt tiedCaller
+        setXcor.call(turtle, turtle.xcor + dx, this)
+      return
+  )
+
+  return
+
+# (Number, Turtle) => Unit
+setYcor = (newY, tiedCaller = undefined) ->
+
+  originPatch = @getPatchHere()
+  oldY        = @ycor
+  @ycor       = @world.topology.wrapY(newY)
+  @_updateVarsByName("ycor")
+  @_drawLine(@xcor, oldY, @xcor, newY)
+
+  if originPatch isnt @getPatchHere()
+    originPatch.untrackTurtle(this)
+    @getPatchHere().trackTurtle(this)
+
+  @linkManager._refresh()
+
+  dy = @ycor - oldY
+  @_tiedTurtles().forEach(
+    (turtle) =>
+      if turtle isnt tiedCaller
+        setYcor.call(turtle, turtle.ycor + dy, this)
+      return
+  )
+
+  return
+
+# (String) => Unit
+setBreedShape = (shape) ->
+  @_breedShape = shape.toLowerCase()
+  if not @_givenShape?
+    @_genVarUpdate("shape")
+  return
+
+# (AbstractAgentSet|Breed|String) => Unit
+setBreed = (breed) ->
+
+  type = NLType(breed)
+
+  trueBreed =
+    if type.isString()
+      @world.breedManager.get(breed)
+    else if type.isAgentSet()
+      specialName = breed.getSpecialName()
+      if specialName?
+        @world.breedManager.get(specialName)
+      else
+        throw new Error("You can't set BREED to a non-breed agentset.")
+    else
+      breed
+
+  if @_breed? and @_breed isnt trueBreed
+    @_givenShape = undefined
+
+  if @_breed isnt trueBreed
+    trueBreed.add(this)
+    @_breed?.remove(this)
+
+    newNames = @_varNamesForBreed(trueBreed)
+    oldNames = @_varNamesForBreed(@_breed)
+    @_varManager.refineBy(oldNames, newNames)
+
+  @_breed = trueBreed
+  @_genVarUpdate("breed")
+
+  setBreedShape.call(this, trueBreed.getShape())
+
+  if trueBreed isnt @world.breedManager.turtles()
+    @world.breedManager.turtles().add(this)
+
+  return
+
+# (Number) => Unit
+setColor = (color) ->
+  @_color = ColorModel.wrapColor(color)
+  @_genVarUpdate("color")
+  return
+
+# (Number, Turtle) => Unit
+setHeading = (heading, tiedCaller = undefined) ->
+
+  oldHeading = @_heading
+  @_heading  = @_normalizeHeading(heading)
+  @_genVarUpdate("heading")
+
+  dh      = @_heading - oldHeading
+  [x, y]  = @getCoords()
+
+  @_fixedTiedTurtles().forEach(
+    (turtle) =>
+      if turtle isnt tiedCaller
+        turtle.right(dh, this)
+      return
+  )
+
+  @_tiedTurtles().forEach(
+    (turtle) =>
+      if turtle isnt tiedCaller
+        r        = @distance(turtle)
+        [tx, ty] = turtle.getCoords()
+        theta    = StrictMath.toDegrees(StrictMath.atan2(ty - y, x - tx)) - 90 + dh
+        newX     = x + r * NLMath.squash(NLMath.sin(theta))
+        newY     = y + r * NLMath.squash(NLMath.cos(theta))
+        turtle.setXY(newX, newY, this)
+      return
+  )
+
+  return
+
+# (Boolean) => Unit
+setIsHidden = (isHidden) ->
+  @_hidden = isHidden
+  @_genVarUpdate("hidden?")
+  return
+
+# (String) => Unit
+setLabel = (label) ->
+  @_label = label
+  @_genVarUpdate("label")
+  return
+
+# (Number) => Unit
+setLabelColor = (color) ->
+  @_labelcolor = ColorModel.wrapColor(color)
+  @_genVarUpdate("label-color")
+  return
+
+# (String) => Unit
+setShape = (shape) ->
+  @_givenShape = shape.toLowerCase()
+  @_genVarUpdate("shape")
+  return
+
+# (Number) => Unit
+setSize = (size) ->
+  @_size = size
+  @_genVarUpdate("size")
+  return
+
+Setters = {
+  setXcor
+  setYcor
+  setBreed
+  setColor
+  setHeading
+  setIsHidden
+  setLabel
+  setLabelColor
+  setShape
+  setSize
+}
+
+getBreed = (-> @world.turtleManager.turtlesOfBreed(@_breed.name))
+
+VariableSpecs = [
+  new ImmutableVariableSpec('who', -> @id)
+, new MutableVariableSpec('breed',       getBreed,                              setBreed)
+, new MutableVariableSpec('color',       (-> @_color),                          setColor)
+, new MutableVariableSpec('heading',     (-> @_heading),                        setHeading)
+, new MutableVariableSpec('hidden?',     (-> @_hidden),                         setIsHidden)
+, new MutableVariableSpec('label',       (-> @_label),                          setLabel)
+, new MutableVariableSpec('label-color', (-> @_labelcolor),                     setLabelColor)
+, new MutableVariableSpec('pen-mode',    (-> @penManager.getMode().toString()), ((x) -> @penManager.setPenMode(x)))
+, new MutableVariableSpec('pen-size',    (-> @penManager.getSize()),            ((x) -> @penManager.setSize(x)))
+, new MutableVariableSpec('shape',       (-> @_getShape()),                     setShape)
+, new MutableVariableSpec('size',        (-> @_size),                           setSize)
+, new MutableVariableSpec('xcor',        (-> @xcor),                            setXcor)
+, new MutableVariableSpec('ycor',        (-> @ycor),                            setYcor)
+]
+
+module.exports = {
+  Setters
+  VariableSpecs
+}


### PR DESCRIPTION
Wanted to put this up for review. It was inspired by [Tortoise#168](https://github.com/NetLogo/Tortoise/issues/168). I don't know that it solves the exact problem, since it doesn't reduce memory consumption when idle, but it *does* reduce patch memory consumption by somewhere between 25 and 40%, depending on the number of patch variables. It should correspondingly reduce turtle memory consumption as well.

The technique for reducing memory is primarily to create fewer closures. In a side-by-side before-and-after comparison, I used the acoustics model with ~40k patches.

|      | Total Memory Used | Each Patch Retained Size | Variable Manager Retained Size | # of Closures |
| --- | --- | --- | --- | --- |
| Before | 189M | 3720 | 3144 | ~1M |
| After (no updater changes) |  154M | 2352 | 1808 | ~ 405K |
| w/Updater changes | 117M | 1952 | 1808 | ~325K |

I don't think that this is the final word in reducing patch memory usage. This fix took a few hours and altered very little of the internal engine structure. More involved changes could probably yield even more impressive savings, given that 2k to store a patch is still a lot more than the data contained within the patch.


A quick note on what was generating so many closures before. The body of `Patch._genVarManager` looked like this:
```javascript
    Patch.prototype._genVarManager = function(extraVarNames) {
      var varBundles;
      varBundles = [
        {
          name: 'id',
          get: ((function(_this) {
            return function() {
              return _this.id;
            };
          })(this)),
          set: (function() {})
        }, {
          name: 'pcolor',
          get: ((function(_this) {
            return function() {
              return _this._pcolor;
            };
          })(this)),
          set: ((function(_this) {
            return function(x) {
              return _this._setPcolor(x);
            };
          })(this))
        },
      // ...
```
This means that for each built-in patch property (including properties that were not writable) two closures were being generated per patch.