### PR TITLE
Report errors using token text, rather than command/reporter class name

### DIFF
--- a/jvm/src/test/scala/TortoiseFixture.scala
+++ b/jvm/src/test/scala/TortoiseFixture.scala
@@ -106,7 +106,7 @@ class TortoiseFixture(name: String, nashorn: Nashorn, notImplemented: (String) =
   }
 
   private def cautiously[T](t: => T): T = {
-    val notImplementedMessages = Seq("unknown primitive: ", "unknown settable: ", "unknown language feature: ")
+    val notImplementedMessages = Seq("unimplemented primitive: ", "unknown settable: ", "unknown language feature: ")
     try t
     catch {
       case ex: CompilerException if notImplementedMessages.exists(ex.getMessage.startsWith) =>

--- a/tortoise/src/main/scala/Prims.scala
+++ b/tortoise/src/main/scala/Prims.scala
@@ -150,7 +150,7 @@ trait ReporterPrims extends PrimUtils {
       case _ if compilerFlags.generateUnimplemented =>
         generateNotImplementedStub(r.reporter.getClass.getName.drop(1))
       case _                                        =>
-        failCompilation(s"unknown primitive: ${r.reporter.getClass.getName}", r.instruction.token)
+        failCompilation(s"unimplemented primitive: ${r.instruction.token.text}", r.instruction.token)
 
     }
   }
@@ -215,7 +215,7 @@ trait CommandPrims extends PrimUtils {
       case _ if compilerFlags.generateUnimplemented =>
         s"${generateNotImplementedStub(s.command.getClass.getName.drop(1))};"
       case _                                        =>
-        failCompilation(s"unknown primitive: ${s.command.getClass.getName}", s.instruction.token)
+        failCompilation(s"unimplemented primitive: ${s.instruction.token.text}", s.instruction.token)
     }
   }
   // scalastyle:on method.length


### PR DESCRIPTION
This is a small change to support a request Uri made that the token name be unobscured by the miscellaneous class data in error messages.