### PR TITLE
Agent set optimizations for `one-of`

### DIFF
--- a/compiler/shared/src/test/scala/Model.scala
+++ b/compiler/shared/src/test/scala/Model.scala
@@ -489,6 +489,10 @@ object Model {
     Model(
       path = "models/Code Examples/Network Example.nlogo",
       repetitions = 30
+    ),
+    Model(
+      path = "models/Sample Models/Biology/Evolution/Rock Paper Scissors.nlogo",
+      repetitions = 20
     )
   )
 }

--- a/engine/src/main/coffee/engine/core/abstractagentset.coffee
+++ b/engine/src/main/coffee/engine/core/abstractagentset.coffee
@@ -78,9 +78,17 @@ module.exports =
     isEmpty: ->
       @size() is 0
 
-    # () => Iterator
+    # () => Iterator[T]
     iterator: ->
       new Iterator(@_agentArr[..])
+
+    # This is marked "private" and named "unsafe" for a reason.  Since it does not copy the underlying agent array
+    # it should only be used internally by the agent set when the resulting Iterator will immediately calculate or
+    # tranform to a new value for the consumer.  --JMB, August 2018
+
+    # () => Iterator[T]
+    _unsafeIterator: ->
+      new Iterator(@_agentArr)
 
     # (() => Number) => AbstractAgentSet[T]
     maxesBy: (f) ->

--- a/engine/src/main/coffee/engine/core/abstractagentset.coffee
+++ b/engine/src/main/coffee/engine/core/abstractagentset.coffee
@@ -128,10 +128,19 @@ module.exports =
     minsBy: (f) ->
       @copyWithNewAgents(@_findMinsBy(f))
 
-
     # [Result] @ (() => Result) => Array[Result]
     projectionBy: (f) ->
       @shufflerator().map(@_world.selfManager.askAgent(f))
+
+    # () => T
+    randomAgent: () ->
+      iter  = @_unsafeIterator()
+      count = iter.size()
+      if count is 0
+        Nobody
+      else
+        choice = @_world.rng.nextInt(count)
+        iter.nthItem(choice)
 
     # () => AbstractAgentSet[T]
     shuffled: ->

--- a/engine/src/main/coffee/engine/core/abstractagentset.coffee
+++ b/engine/src/main/coffee/engine/core/abstractagentset.coffee
@@ -80,7 +80,7 @@ module.exports =
 
     # () => Iterator
     iterator: ->
-      new Iterator(@_agentArr)
+      new Iterator(@_agentArr[..])
 
     # (() => Number) => AbstractAgentSet[T]
     maxesBy: (f) ->

--- a/engine/src/main/coffee/engine/core/abstractagentset.coffee
+++ b/engine/src/main/coffee/engine/core/abstractagentset.coffee
@@ -128,6 +128,7 @@ module.exports =
     minsBy: (f) ->
       @copyWithNewAgents(@_findMinsBy(f))
 
+
     # [Result] @ (() => Result) => Array[Result]
     projectionBy: (f) ->
       @shufflerator().map(@_world.selfManager.askAgent(f))
@@ -142,7 +143,7 @@ module.exports =
 
     # () => Number
     size: ->
-      @toArray().length
+      @_unsafeIterator().size()
 
     # () => Array[T]
     sort: ->

--- a/engine/src/main/coffee/engine/core/linkset.coffee
+++ b/engine/src/main/coffee/engine/core/linkset.coffee
@@ -13,7 +13,11 @@ module.exports =
 
     # () => Iterator[T]
     iterator: ->
-      new DeadSkippingIterator(@_unwrap(@_agents))
+      new DeadSkippingIterator(@_unwrap(@_agents, true))
+
+    # () => Iterator[T]
+    _unsafeIterator: ->
+      new DeadSkippingIterator(@_unwrap(@_agents, false))
 
     # I know, I know, this is insane, right?  "Why would you do this?!", you demand.  I don't blame you.  I don't like
     # it, either.  But, look... we have a problem on our hands.  Special agentsets are a thing.  They can be stored
@@ -24,5 +28,5 @@ module.exports =
     # array, or we need to use a good sorting structure that represents the data as an array under the hood, and then
     # we can pass around that array.  Passing thunks seems to be the better option to me.  --JAB (9/7/14)
     # [T] @ ((() => Array[T])|Array[T]) => Array[T]
-    _unwrap: (agents) ->
-      if JSType(agents).isFunction() then agents() else agents[..]
+    _unwrap: (agents, copy) ->
+      if JSType(agents).isFunction() then agents() else if copy then agents[..] else agents

--- a/engine/src/main/coffee/engine/core/structure/deadskippingiterator.coffee
+++ b/engine/src/main/coffee/engine/core/structure/deadskippingiterator.coffee
@@ -46,6 +46,12 @@ module.exports =
         f(@_next())
       return
 
+    # () => Int
+    size: ->
+      @_items.reduce( (acc, item) ->
+        acc + if item.isDead() then 0 else 1
+      , 0)
+
     # () => Array[T]
     toArray: ->
       acc = []

--- a/engine/src/main/coffee/engine/core/structure/deadskippingiterator.coffee
+++ b/engine/src/main/coffee/engine/core/structure/deadskippingiterator.coffee
@@ -46,6 +46,22 @@ module.exports =
         f(@_next())
       return
 
+    # They're asking for the `n`th not-dead item, so every time we see a dead item, increment the index and the `n`.
+
+    # start           iteration 1     iteration 2     iteration 3     iteration 4
+    # [0][X][X][1][2] [0][X][X][1][2] [0][X][X][1][2] [0][X][X][1][2] [0][X][X][1][2]
+    # i=0                i=1                i=2                i=3                i=4
+    #       n=2             n=2                n=3                n=4             n=4
+
+    # (Int) => T
+    nthItem: (n) ->
+      i = 0
+      while i <= n
+        if @_items[i].isDead()
+          n++
+        i++
+      @_items[n]
+
     # () => Int
     size: ->
       @_items.reduce( (acc, item) ->

--- a/engine/src/main/coffee/engine/core/turtleset.coffee
+++ b/engine/src/main/coffee/engine/core/turtleset.coffee
@@ -13,3 +13,7 @@ module.exports =
     # () => Iterator[T]
     iterator: ->
       new DeadSkippingIterator(@_agents[..])
+
+    # () => Iterator[T]
+    _unsafeIterator: ->
+      new DeadSkippingIterator(@_agents)

--- a/engine/src/main/coffee/engine/core/turtleset.coffee
+++ b/engine/src/main/coffee/engine/core/turtleset.coffee
@@ -12,4 +12,4 @@ module.exports =
 
     # () => Iterator[T]
     iterator: ->
-      new DeadSkippingIterator(@_agents)
+      new DeadSkippingIterator(@_agents[..])

--- a/engine/src/main/coffee/engine/prim/listprims.coffee
+++ b/engine/src/main/coffee/engine/prim/listprims.coffee
@@ -169,16 +169,13 @@ module.exports =
     oneOf: (agentsOrList) ->
       type = NLType(agentsOrList)
 
-      arr =
-        if type.isAgentSet()
-          agentsOrList.iterator().toArray()
-        else
-          agentsOrList
-
-      if arr.length is 0
-        Nobody
+      if type.isAgentSet()
+        agentsOrList.randomAgent()
       else
-        arr[@_nextInt(arr.length)]
+        if agentsOrList.length is 0
+          Nobody
+        else
+          agentsOrList[@_nextInt(agentsOrList.length)]
 
     # [Item, Container <: (Array[Item]|String)] @ (Item, Container) => Number|Boolean
     position: (x, xs) ->

--- a/engine/src/main/coffee/util/iterator.coffee
+++ b/engine/src/main/coffee/util/iterator.coffee
@@ -51,6 +51,10 @@ module.exports =
       else
         throw new Error("WITH expected a true/false value from #{x}, but got #{y} instead.")
 
+    # (Int) => T
+    nthItem: (n) ->
+      @_items[n]
+
     # [U] @ ((T) => U) => Array[U]
     map: (f) ->
       @_items.map(f)

--- a/engine/src/main/coffee/util/iterator.coffee
+++ b/engine/src/main/coffee/util/iterator.coffee
@@ -60,6 +60,10 @@ module.exports =
       @_items.forEach(f)
       return
 
+    # () => Int
+    size: ->
+      @_items.length
+
     # () => Array[T]
     toArray: ->
       @_items

--- a/engine/src/main/coffee/util/iterator.coffee
+++ b/engine/src/main/coffee/util/iterator.coffee
@@ -6,8 +6,7 @@ module.exports =
     _items: undefined # [T] @ Array[T]
 
     # (Array[T]) => Iterator[T]
-    constructor: (items) ->
-      @_items = items[..]
+    constructor: (@_items) ->
 
     # ((T) => Boolean) => Boolean
     all: (f) ->

--- a/resources/test/dumps/Rock Paper Scissors.js
+++ b/resources/test/dumps/Rock Paper Scissors.js
@@ -1,0 +1,385 @@
+var AgentModel = tortoise_require('agentmodel');
+var ColorModel = tortoise_require('engine/core/colormodel');
+var Exception = tortoise_require('util/exception');
+var Link = tortoise_require('engine/core/link');
+var LinkSet = tortoise_require('engine/core/linkset');
+var Meta = tortoise_require('meta');
+var NLMath = tortoise_require('util/nlmath');
+var NLType = tortoise_require('engine/core/typechecker');
+var PatchSet = tortoise_require('engine/core/patchset');
+var PenBundle = tortoise_require('engine/plot/pen');
+var Plot = tortoise_require('engine/plot/plot');
+var PlotOps = tortoise_require('engine/plot/plotops');
+var Random = tortoise_require('shim/random');
+var StrictMath = tortoise_require('shim/strictmath');
+var Tasks = tortoise_require('engine/prim/tasks');
+var Turtle = tortoise_require('engine/core/turtle');
+var TurtleSet = tortoise_require('engine/core/turtleset');
+var notImplemented = tortoise_require('util/notimplemented');
+var linkShapes = {"default":{"name":"default","direction-indicator":{"name":"link direction","editableColorIndex":0,"rotate":true,"elements":[{"x1":150,"y1":150,"x2":90,"y2":180,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":150,"y1":150,"x2":210,"y2":180,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"curviness":0,"lines":[{"x-offset":-0.2,"is-visible":false,"dash-pattern":[0,1]},{"x-offset":0,"is-visible":true,"dash-pattern":[1,0]},{"x-offset":0.2,"is-visible":false,"dash-pattern":[0,1]}]}};
+var modelConfig = (typeof window.modelConfig !== "undefined" && window.modelConfig !== null) ? window.modelConfig : {};
+var turtleShapes = {"default":{"name":"default","editableColorIndex":0,"rotate":true,"elements":[{"xcors":[150,40,150,260],"ycors":[5,250,205,250],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"airplane":{"name":"airplane","editableColorIndex":0,"rotate":true,"elements":[{"xcors":[150,135,120,120,15,15,120,135,105,120,150,180,210,165,180,285,285,180,180,165],"ycors":[0,15,60,105,165,195,180,240,270,285,270,285,270,240,180,195,165,105,60,15],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"arrow":{"name":"arrow","editableColorIndex":0,"rotate":true,"elements":[{"xcors":[150,0,105,105,195,195,300],"ycors":[0,150,150,293,293,150,150],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"box":{"name":"box","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[150,285,285,150],"ycors":[285,225,75,135],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[150,15,150,285],"ycors":[135,75,15,75],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[15,15,150,150],"ycors":[75,225,285,135],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x1":150,"y1":285,"x2":150,"y2":135,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false},{"x1":150,"y1":135,"x2":15,"y2":75,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false},{"x1":150,"y1":135,"x2":285,"y2":75,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false}]},"bug":{"name":"bug","editableColorIndex":0,"rotate":true,"elements":[{"x":96,"y":182,"diam":108,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":110,"y":127,"diam":80,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":110,"y":75,"diam":80,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x1":150,"y1":100,"x2":80,"y2":30,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":150,"y1":100,"x2":220,"y2":30,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"butterfly":{"name":"butterfly","editableColorIndex":0,"rotate":true,"elements":[{"xcors":[150,209,225,225,195,165,150],"ycors":[165,199,225,255,270,255,240],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[150,89,75,75,105,135,150],"ycors":[165,198,225,255,270,255,240],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[139,100,55,25,10,10,25,40,85,139],"ycors":[148,105,90,90,105,135,180,195,194,163],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[162,200,245,275,290,290,275,260,215,162],"ycors":[150,105,90,90,105,135,180,195,195,165],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[150,135,120,135,150,165,180,165],"ycors":[255,225,150,120,105,120,150,225],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":135,"y":90,"diam":30,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x1":150,"y1":105,"x2":195,"y2":60,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false},{"x1":150,"y1":105,"x2":105,"y2":60,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false}]},"car":{"name":"car","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[300,279,261,240,226,213,203,185,159,135,75,0,0,0,300,300],"ycors":[180,164,144,135,132,106,84,63,50,50,60,150,165,225,225,180],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":180,"y":180,"diam":90,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":30,"y":180,"diam":90,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[162,132,134,209,194,189,180],"ycors":[80,78,135,135,105,96,89],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":47,"y":195,"diam":58,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":195,"y":195,"diam":58,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"circle":{"name":"circle","editableColorIndex":0,"rotate":false,"elements":[{"x":0,"y":0,"diam":300,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"circle 2":{"name":"circle 2","editableColorIndex":0,"rotate":false,"elements":[{"x":0,"y":0,"diam":300,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":30,"y":30,"diam":240,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"cow":{"name":"cow","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[200,197,179,177,166,140,93,78,72,49,48,37,25,25,45,103,179,198,252,272,293,285,255,242,224],"ycors":[193,249,249,196,187,189,191,179,211,209,181,149,120,89,72,84,75,76,64,81,103,121,121,118,167],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[73,86,62,48],"ycors":[210,251,249,208],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[25,16,9,23,25,39],"ycors":[114,195,204,213,200,123],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"cylinder":{"name":"cylinder","editableColorIndex":0,"rotate":false,"elements":[{"x":0,"y":0,"diam":300,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"dot":{"name":"dot","editableColorIndex":0,"rotate":false,"elements":[{"x":90,"y":90,"diam":120,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"face happy":{"name":"face happy","editableColorIndex":0,"rotate":false,"elements":[{"x":8,"y":8,"diam":285,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":60,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":180,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[150,90,62,47,67,90,109,150,192,210,227,251,236,212],"ycors":[255,239,213,191,179,203,218,225,218,203,181,194,217,240],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"face neutral":{"name":"face neutral","editableColorIndex":0,"rotate":false,"elements":[{"x":8,"y":7,"diam":285,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":60,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":180,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xmin":60,"ymin":195,"xmax":240,"ymax":225,"type":"rectangle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"face sad":{"name":"face sad","editableColorIndex":0,"rotate":false,"elements":[{"x":8,"y":8,"diam":285,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":60,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":180,"y":75,"diam":60,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[150,90,62,47,67,90,109,150,192,210,227,251,236,212],"ycors":[168,184,210,232,244,220,205,198,205,220,242,229,206,183],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"fish":{"name":"fish","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[44,21,15,0,15,0,13,20,45],"ycors":[131,87,86,120,150,180,214,212,166],"type":"polygon","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":false},{"xcors":[135,119,95,76,46,60],"ycors":[195,235,218,210,204,165],"type":"polygon","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":false},{"xcors":[75,83,71,86,166,135],"ycors":[45,77,103,114,78,60],"type":"polygon","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":false},{"xcors":[30,151,226,280,292,292,287,270,195,151,30],"ycors":[136,77,81,119,146,160,170,195,210,212,166],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":215,"y":106,"diam":30,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"flag":{"name":"flag","editableColorIndex":0,"rotate":false,"elements":[{"xmin":60,"ymin":15,"xmax":75,"ymax":300,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[90,270,90],"ycors":[150,90,30],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x1":75,"y1":135,"x2":90,"y2":135,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":75,"y1":45,"x2":90,"y2":45,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"flower":{"name":"flower","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[135,165,180,180,150,165,195,195,165],"ycors":[120,165,210,240,300,300,240,195,135],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"x":85,"y":132,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":130,"y":147,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":192,"y":85,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":85,"y":40,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":177,"y":40,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":177,"y":132,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":70,"y":85,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":130,"y":25,"diam":38,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":96,"y":51,"diam":108,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":113,"y":68,"diam":74,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[189,219,249,279,234],"ycors":[233,188,173,188,218],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[180,150,105,75,135],"ycors":[255,210,210,240,240],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false}]},"house":{"name":"house","editableColorIndex":0,"rotate":false,"elements":[{"xmin":45,"ymin":120,"xmax":255,"ymax":285,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xmin":120,"ymin":210,"xmax":180,"ymax":285,"type":"rectangle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[15,150,285],"ycors":[120,15,120],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x1":30,"y1":120,"x2":270,"y2":120,"type":"line","color":"rgba(0, 0, 0, 1.0)","filled":false,"marked":false}]},"leaf":{"name":"leaf","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[150,135,120,60,30,60,60,15,30,15,40,45,60,90,105,120,105,120,135,150,165,180,195,180,195,210,240,255,263,285,270,285,240,240,270,240,180,165],"ycors":[210,195,210,210,195,180,165,135,120,105,104,90,90,105,120,120,60,60,30,15,30,60,60,120,120,105,90,90,104,105,120,135,165,180,195,210,210,195],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[135,135,120,105,105,135,165,165],"ycors":[195,240,255,255,285,285,240,195],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"line":{"name":"line","editableColorIndex":0,"rotate":true,"elements":[{"x1":150,"y1":0,"x2":150,"y2":300,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"line half":{"name":"line half","editableColorIndex":0,"rotate":true,"elements":[{"x1":150,"y1":0,"x2":150,"y2":150,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"pentagon":{"name":"pentagon","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[150,15,60,240,285],"ycors":[15,120,285,285,120],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"person":{"name":"person","editableColorIndex":0,"rotate":false,"elements":[{"x":110,"y":5,"diam":80,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[105,120,90,105,135,150,165,195,210,180,195],"ycors":[90,195,285,300,300,225,300,300,285,195,90],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xmin":127,"ymin":79,"xmax":172,"ymax":94,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[195,240,225,165],"ycors":[90,150,180,105],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[105,60,75,135],"ycors":[90,150,180,105],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"plant":{"name":"plant","editableColorIndex":0,"rotate":false,"elements":[{"xmin":135,"ymin":90,"xmax":165,"ymax":300,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[135,90,45,75,135],"ycors":[255,210,195,255,285],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[165,210,255,225,165],"ycors":[255,210,195,255,285],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[135,90,45,75,135],"ycors":[180,135,120,180,210],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[165,165,225,255,210],"ycors":[180,210,180,120,135],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[135,90,45,75,135],"ycors":[105,60,45,105,135],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[165,165,225,255,210],"ycors":[105,135,105,45,60],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[135,120,150,180,165],"ycors":[90,45,15,45,90],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"sheep":{"name":"sheep","editableColorIndex":15,"rotate":false,"elements":[{"x":203,"y":65,"diam":88,"type":"circle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"x":70,"y":65,"diam":162,"type":"circle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"x":150,"y":105,"diam":120,"type":"circle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"xcors":[218,240,255,278],"ycors":[120,165,165,120],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":false},{"x":214,"y":72,"diam":67,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":false},{"xmin":164,"ymin":223,"xmax":179,"ymax":298,"type":"rectangle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"xcors":[45,30,30,15,45],"ycors":[285,285,240,195,210],"type":"polygon","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"x":3,"y":83,"diam":150,"type":"circle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"xmin":65,"ymin":221,"xmax":80,"ymax":296,"type":"rectangle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"xcors":[195,210,210,240,195],"ycors":[285,285,240,210,210],"type":"polygon","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":true},{"xcors":[276,285,302,294],"ycors":[85,105,99,83],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":false},{"xcors":[219,210,193,201],"ycors":[85,105,99,83],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":false}]},"square":{"name":"square","editableColorIndex":0,"rotate":false,"elements":[{"xmin":30,"ymin":30,"xmax":270,"ymax":270,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"square 2":{"name":"square 2","editableColorIndex":0,"rotate":false,"elements":[{"xmin":30,"ymin":30,"xmax":270,"ymax":270,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xmin":60,"ymin":60,"xmax":240,"ymax":240,"type":"rectangle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"star":{"name":"star","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[151,185,298,207,242,151,59,94,3,116],"ycors":[1,108,108,175,282,216,282,175,108,108],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"target":{"name":"target","editableColorIndex":0,"rotate":false,"elements":[{"x":0,"y":0,"diam":300,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":30,"y":30,"diam":240,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":60,"y":60,"diam":180,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":90,"y":90,"diam":120,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":120,"y":120,"diam":60,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"tree":{"name":"tree","editableColorIndex":0,"rotate":false,"elements":[{"x":118,"y":3,"diam":94,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xmin":120,"ymin":195,"xmax":180,"ymax":300,"type":"rectangle","color":"rgba(157, 110, 72, 1.0)","filled":true,"marked":false},{"x":65,"y":21,"diam":108,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":116,"y":41,"diam":127,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":45,"y":90,"diam":120,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":104,"y":74,"diam":152,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"triangle":{"name":"triangle","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[150,15,285],"ycors":[30,255,255],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"triangle 2":{"name":"triangle 2","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[150,15,285],"ycors":[30,255,255],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[151,225,75],"ycors":[99,223,224],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false}]},"truck":{"name":"truck","editableColorIndex":0,"rotate":false,"elements":[{"xmin":4,"ymin":45,"xmax":195,"ymax":187,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[296,296,259,244,208,207],"ycors":[193,150,134,104,104,194],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xmin":195,"ymin":60,"xmax":195,"ymax":105,"type":"rectangle","color":"rgba(255, 255, 255, 1.0)","filled":true,"marked":false},{"xcors":[238,252,219,218],"ycors":[112,141,141,112],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":234,"y":174,"diam":42,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xmin":181,"ymin":185,"xmax":214,"ymax":194,"type":"rectangle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":144,"y":174,"diam":42,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":24,"y":174,"diam":42,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x":24,"y":174,"diam":42,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x":144,"y":174,"diam":42,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x":234,"y":174,"diam":42,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"turtle":{"name":"turtle","editableColorIndex":0,"rotate":true,"elements":[{"xcors":[215,240,246,228,215,193],"ycors":[204,233,254,266,252,210],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[195,225,245,260,269,261,240,225,210],"ycors":[90,75,75,89,108,124,105,105,105],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[105,75,55,40,31,39,60,75,90],"ycors":[90,75,75,89,108,124,105,105,105],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[132,134,107,108,150,192,192,169,172],"ycors":[85,64,51,17,2,18,52,65,87],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[85,60,54,72,85,107],"ycors":[204,233,254,266,252,210],"type":"polygon","color":"rgba(89, 176, 60, 1.0)","filled":true,"marked":false},{"xcors":[119,179,209,224,220,175,128,81,74,88],"ycors":[75,75,101,135,225,261,261,224,135,99],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"wheel":{"name":"wheel","editableColorIndex":0,"rotate":false,"elements":[{"x":3,"y":3,"diam":294,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x":30,"y":30,"diam":240,"type":"circle","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"x1":150,"y1":285,"x2":150,"y2":15,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":15,"y1":150,"x2":285,"y2":150,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x":120,"y":120,"diam":60,"type":"circle","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"x1":216,"y1":40,"x2":79,"y2":269,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":40,"y1":84,"x2":269,"y2":221,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":40,"y1":216,"x2":269,"y2":79,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true},{"x1":84,"y1":40,"x2":221,"y2":269,"type":"line","color":"rgba(141, 141, 141, 1.0)","filled":false,"marked":true}]},"wolf":{"name":"wolf","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[253,245,245],"ycors":[133,131,133],"type":"polygon","color":"rgba(0, 0, 0, 1.0)","filled":true,"marked":false},{"xcors":[2,13,30,38,38,20,20,27,38,40,31,31,60,68,75,66,65,82,84,100,103,77,79,100,98,119,143,160,166,172,173,167,160,154,169,178,186,198,200,217,219,207,195,192,210,227,242,259,284,277,293,299,297,273,270],"ycors":[194,197,191,193,205,226,257,265,266,260,253,230,206,198,209,228,243,261,268,267,261,239,231,207,196,201,202,195,210,213,238,251,248,265,264,247,240,260,271,271,262,258,230,198,184,164,144,145,151,141,140,134,127,119,105],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[-1,14,36,40,53,82,134,159,188,227,236,238,268,269,281,269,269],"ycors":[195,180,166,153,140,131,133,126,115,108,102,98,86,92,87,103,113],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]},"x":{"name":"x","editableColorIndex":0,"rotate":false,"elements":[{"xcors":[270,225,30,75],"ycors":[75,30,225,270],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true},{"xcors":[30,75,270,225],"ycors":[75,30,225,270],"type":"polygon","color":"rgba(141, 141, 141, 1.0)","filled":true,"marked":true}]}};
+if (typeof javax !== "undefined") {
+  modelConfig.dialog = {
+    confirm: function(str) { return true; },
+    input: function(str) { return 'dummy implementation'; },
+    notify: function(str) {},
+    yesOrNo: function(str) { return true; }
+  }
+}
+if (typeof javax !== "undefined") {
+  modelConfig.importExport = {
+    importWorld: function(trueImportWorld) {
+      return function(filename) {
+        var Paths = Java.type('java.nio.file.Paths');
+        var Files = Java.type('java.nio.file.Files');
+        var UTF8  = Java.type('java.nio.charset.StandardCharsets').UTF_8;
+        var lines = Files.readAllLines(Paths.get(filename), UTF8);
+        var out   = [];
+        lines.forEach(function(line) { out.push(line); });
+        var fileText = out.join("\n");
+        trueImportWorld(fileText);
+      }
+},
+    exportFile: function(str) {
+      return function(filepath) {
+        var Paths = Java.type('java.nio.file.Paths');
+        var Files = Java.type('java.nio.file.Files');
+        var UTF8  = Java.type('java.nio.charset.StandardCharsets').UTF_8;
+        Files.createDirectories(Paths.get(filepath).getParent());
+        var path  = Files.write(Paths.get(filepath), str.getBytes());
+      }
+},
+    importDrawing: function(trueImportDrawing) { return function(filepath) {} },
+    exportView: function(filename) {},
+    exportOutput: function(filename) {}
+  }
+}
+if (typeof javax !== "undefined") {
+  modelConfig.inspection = {
+    inspect: function(agent) {},
+    stopInspecting: function(agent) {},
+    clearDead: function() {}
+  }
+}
+if (typeof javax !== "undefined") {
+  modelConfig.output = {
+    clear: function() {},
+    write: function(str) { context.getWriter().print(str); }
+  }
+}
+if (typeof javax !== "undefined") {
+  modelConfig.world = {
+    resizeWorld: function(agent) {}
+  }
+}
+var modelPlotOps = (typeof modelConfig.plotOps !== "undefined" && modelConfig.plotOps !== null) ? modelConfig.plotOps : {};
+modelConfig.plots = [(function() {
+  var name    = 'Populations';
+  var plotOps = (typeof modelPlotOps[name] !== "undefined" && modelPlotOps[name] !== null) ? modelPlotOps[name] : new PlotOps(function() {}, function() {}, function() {}, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; }, function() { return function() {}; });
+  var pens    = [new PenBundle.Pen('default', plotOps.makePenOps, false, new PenBundle.State(15.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
+    return workspace.rng.withClone(function() {
+      return plotManager.withTemporaryContext('Populations', 'default')(function() {
+        try {
+          var reporterContext = false;
+          var letVars = { };
+          plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 15); }).size());
+        } catch (e) {
+          if (e instanceof Exception.StopInterrupt) {
+            return e;
+          } else {
+            throw e;
+          }
+        };
+      });
+    });
+  }),
+  new PenBundle.Pen('pen-1', plotOps.makePenOps, false, new PenBundle.State(55.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
+    return workspace.rng.withClone(function() {
+      return plotManager.withTemporaryContext('Populations', 'pen-1')(function() {
+        try {
+          var reporterContext = false;
+          var letVars = { };
+          plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 55); }).size());
+        } catch (e) {
+          if (e instanceof Exception.StopInterrupt) {
+            return e;
+          } else {
+            throw e;
+          }
+        };
+      });
+    });
+  }),
+  new PenBundle.Pen('pen-2', plotOps.makePenOps, false, new PenBundle.State(105.0, 1.0, PenBundle.DisplayMode.Line), function() {}, function() {
+    return workspace.rng.withClone(function() {
+      return plotManager.withTemporaryContext('Populations', 'pen-2')(function() {
+        try {
+          var reporterContext = false;
+          var letVars = { };
+          plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 105); }).size());
+        } catch (e) {
+          if (e instanceof Exception.StopInterrupt) {
+            return e;
+          } else {
+            throw e;
+          }
+        };
+      });
+    });
+  })];
+  var setup   = function() {};
+  var update  = function() {};
+  return new Plot(name, pens, plotOps, "", "", false, true, 0.0, 10.0, 0.0, 10.0, setup, update);
+})()];
+var workspace = tortoise_require('engine/workspace')(modelConfig)([])([], [])('to setup\n  clear-all\n  ask patches [\n    ; Start populations at roughly even levels.\n    set pcolor one-of [ red green blue black ]\n  ]\n  reset-ticks\nend\n\nto go\n  ; This model uses an event-based approach. It calculates how many events of each type\n  ; should occur each tick and then executes those events in a random order. Event type\n  ; could be signified by any constant. Here, we use a the numbers 0, 1, and 2 to signify\n  ; event type, but then store those numbers in variables with clear names for readability.\n  let swap-event 0\n  let reproduce-event 1\n  let select-event 2\n\n  ; Note that we have to compute the number of global events rather than the number of\n  ; actions that each individual patch performs since the execution of those events has\n  ; to be random between the patches. That is, a single patch can\'t perform all of their\n  ; actions in one go: suppose they end up executing 5 swaps in one tick. The swaps would\n  ; be shuffling things around locally rather than allowing for an organism to travel\n  ; multiple steps.\n  ; Hence, this code creates a list with an entry for each event type that should occur\n  ; this tick, then shuffles that list so that the events are in a random order. We then\n  ; iterate through the list, and random neighboring patches run the corresponding event.\n  let repetitions count patches / 3 ; At default settings, there will be an average of 1 event per patch.\n  let events shuffle (sentence\n    n-values random-poisson (repetitions * swap-rate)      [ swap-event ]\n    n-values random-poisson (repetitions * reproduce-rate) [ reproduce-event ]\n    n-values random-poisson (repetitions * select-rate)    [ select-event ]\n  )\n\n  foreach events [ event ->\n    ask one-of patches [\n      let target one-of neighbors4\n      if event = swap-event      [ swap target ]\n      if event = reproduce-event [ reproduce target ]\n      if event = select-event    [ select target ]\n    ]\n  ]\n  tick\nend\n\n; Patch procedures\n\n; Swap PCOLOR with TARGET.\nto swap [ target ]\n  let old-color pcolor\n  set pcolor [ pcolor ] of target\n  ask target [ set pcolor old-color ]\nend\n\n; Compete with TARGET. The loser becomes blank.\nto select [ target ]\n  ifelse beat? target [\n    ask target [ set pcolor black ]\n  ] [\n    if [ beat? myself ] of target [\n      set pcolor black\n    ]\n  ]\nend\n\n; If TARGET is blank, reproduce to it. If I\'m blank, TARGET reproduces to me.\nto reproduce [ target ]\n  ifelse [ pcolor ] of target = black [\n    ask target [\n      set pcolor [ pcolor ] of myself\n    ]\n  ] [\n    if pcolor = black [\n      set pcolor [ pcolor ] of target\n    ]\n  ]\nend\n\n; Determine whether or not I beat TARGET\nto-report beat? [ target ]\n  report (pcolor = red   and [ pcolor ] of target = green) or\n         (pcolor = green and [ pcolor ] of target = blue) or\n         (pcolor = blue  and [ pcolor ] of target = red)\nend\n\n; Utility procedures\n\nto-report rate-from-exponent [ exponent ]\n  report 10 ^ exponent\nend\n\nto-report swap-rate\n  report rate-from-exponent swap-rate-exponent\nend\n\nto-report reproduce-rate\n  report rate-from-exponent reproduce-rate-exponent\nend\n\nto-report select-rate\n  report rate-from-exponent select-rate-exponent\nend\n\n; Convert the given rate to a percentage of how much that action happens\nto-report percentage [ rate ]\n  report 100 * rate / (swap-rate + reproduce-rate + select-rate)\nend\n\n\n; Copyright 2017 Uri Wilensky.\n; See Info tab for full copyright and license.')([{"left":310,"top":10,"right":771,"bottom":472,"dimensions":{"minPxcor":-75,"maxPxcor":75,"minPycor":-75,"maxPycor":75,"patchSize":3,"wrappingAllowedInX":true,"wrappingAllowedInY":true},"fontSize":10,"updateMode":"TickBased","showTickCounter":true,"tickCounterLabel":"ticks","frameRate":30,"type":"view","compilation":{"success":true,"messages":[]}}, {"compiledSource":"try {\n  var reporterContext = false;\n  var letVars = { };\n  let _maybestop_33_38 = procedures[\"SETUP\"]();\n  if (_maybestop_33_38 instanceof Exception.StopInterrupt) { return _maybestop_33_38; }\n} catch (e) {\n  if (e instanceof Exception.StopInterrupt) {\n    return e;\n  } else {\n    throw e;\n  }\n}","source":"setup","left":5,"top":10,"right":100,"bottom":43,"forever":false,"buttonKind":"Observer","disableUntilTicksStart":false,"type":"button","compilation":{"success":true,"messages":[]}}, {"compiledSource":"try {\n  var reporterContext = false;\n  var letVars = { };\n  let _maybestop_33_35 = procedures[\"GO\"]();\n  if (_maybestop_33_35 instanceof Exception.StopInterrupt) { return _maybestop_33_35; }\n} catch (e) {\n  if (e instanceof Exception.StopInterrupt) {\n    return e;\n  } else {\n    throw e;\n  }\n}","source":"go\n","left":115,"top":10,"right":210,"bottom":43,"forever":true,"buttonKind":"Observer","disableUntilTicksStart":true,"type":"button","compilation":{"success":true,"messages":[]}}, {"compiledMin":"-1","compiledMax":"1","compiledStep":"0.1","variable":"swap-rate-exponent","left":5,"top":55,"right":210,"bottom":88,"display":"swap-rate-exponent","min":"-1","max":"1","default":0,"step":"0.1","direction":"horizontal","type":"slider","compilation":{"success":true,"messages":[]}}, {"compiledMin":"-1","compiledMax":"1","compiledStep":"0.1","variable":"reproduce-rate-exponent","left":5,"top":100,"right":210,"bottom":133,"display":"reproduce-rate-exponent","min":"-1","max":"1","default":0,"step":"0.1","direction":"horizontal","type":"slider","compilation":{"success":true,"messages":[]}}, {"compiledMin":"-1","compiledMax":"1","compiledStep":"0.1","variable":"select-rate-exponent","left":5,"top":145,"right":210,"bottom":178,"display":"select-rate-exponent","min":"-1","max":"1","default":0,"step":"0.1","direction":"horizontal","type":"slider","compilation":{"success":true,"messages":[]}}, {"compiledSetupCode":"function() {}","compiledUpdateCode":"function() {}","compiledPens":[{"compiledSetupCode":"function() {}","compiledUpdateCode":"function() {\n  return workspace.rng.withClone(function() {\n    return plotManager.withTemporaryContext('Populations', 'default')(function() {\n      try {\n        var reporterContext = false;\n        var letVars = { };\n        plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable(\"pcolor\"), 15); }).size());\n      } catch (e) {\n        if (e instanceof Exception.StopInterrupt) {\n          return e;\n        } else {\n          throw e;\n        }\n      };\n    });\n  });\n}","display":"default","interval":1,"mode":0,"color":-2674135,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = red ]","type":"pen","compilation":{"success":true,"messages":[]}},{"compiledSetupCode":"function() {}","compiledUpdateCode":"function() {\n  return workspace.rng.withClone(function() {\n    return plotManager.withTemporaryContext('Populations', 'pen-1')(function() {\n      try {\n        var reporterContext = false;\n        var letVars = { };\n        plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable(\"pcolor\"), 55); }).size());\n      } catch (e) {\n        if (e instanceof Exception.StopInterrupt) {\n          return e;\n        } else {\n          throw e;\n        }\n      };\n    });\n  });\n}","display":"pen-1","interval":1,"mode":0,"color":-10899396,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = green ]","type":"pen","compilation":{"success":true,"messages":[]}},{"compiledSetupCode":"function() {}","compiledUpdateCode":"function() {\n  return workspace.rng.withClone(function() {\n    return plotManager.withTemporaryContext('Populations', 'pen-2')(function() {\n      try {\n        var reporterContext = false;\n        var letVars = { };\n        plotManager.plotValue(world.patches().agentFilter(function() { return Prims.equality(SelfManager.self().getPatchVariable(\"pcolor\"), 105); }).size());\n      } catch (e) {\n        if (e instanceof Exception.StopInterrupt) {\n          return e;\n        } else {\n          throw e;\n        }\n      };\n    });\n  });\n}","display":"pen-2","interval":1,"mode":0,"color":-13345367,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = blue ]","type":"pen","compilation":{"success":true,"messages":[]}}],"display":"Populations","left":5,"top":190,"right":305,"bottom":470,"xmin":0,"xmax":10,"ymin":0,"ymax":10,"autoPlotOn":true,"legendOn":false,"setupCode":"","updateCode":"","pens":[{"display":"default","interval":1,"mode":0,"color":-2674135,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = red ]","type":"pen"},{"display":"pen-1","interval":1,"mode":0,"color":-10899396,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = green ]","type":"pen"},{"display":"pen-2","interval":1,"mode":0,"color":-13345367,"inLegend":true,"setupCode":"","updateCode":"plot count patches with [ pcolor = blue ]","type":"pen"}],"type":"plot","compilation":{"success":true,"messages":[]}}, {"compiledSource":"procedures[\"PERCENTAGE\"](procedures[\"SWAP-RATE\"]())","source":"percentage swap-rate","left":215,"top":50,"right":305,"bottom":95,"display":"swap-%","precision":2,"fontSize":11,"type":"monitor","compilation":{"success":true,"messages":[]}}, {"compiledSource":"procedures[\"PERCENTAGE\"](procedures[\"REPRODUCE-RATE\"]())","source":"percentage reproduce-rate","left":215,"top":95,"right":305,"bottom":140,"display":"reproduce-%","precision":2,"fontSize":11,"type":"monitor","compilation":{"success":true,"messages":[]}}, {"compiledSource":"procedures[\"PERCENTAGE\"](procedures[\"SELECT-RATE\"]())","source":"percentage select-rate","left":215,"top":140,"right":305,"bottom":185,"display":"select-%","precision":2,"fontSize":11,"type":"monitor","compilation":{"success":true,"messages":[]}}])(tortoise_require("extensions/all").dumpers())(["swap-rate-exponent", "reproduce-rate-exponent", "select-rate-exponent"], ["swap-rate-exponent", "reproduce-rate-exponent", "select-rate-exponent"], [], -75, 75, -75, 75, 3.0, true, true, turtleShapes, linkShapes, function(){});
+var Extensions = tortoise_require('extensions/all').initialize(workspace);
+var BreedManager = workspace.breedManager;
+var ImportExportPrims = workspace.importExportPrims;
+var InspectionPrims = workspace.inspectionPrims;
+var LayoutManager = workspace.layoutManager;
+var LinkPrims = workspace.linkPrims;
+var ListPrims = workspace.listPrims;
+var MousePrims = workspace.mousePrims;
+var OutputPrims = workspace.outputPrims;
+var Prims = workspace.prims;
+var PrintPrims = workspace.printPrims;
+var SelfManager = workspace.selfManager;
+var SelfPrims = workspace.selfPrims;
+var Updater = workspace.updater;
+var UserDialogPrims = workspace.userDialogPrims;
+var plotManager = workspace.plotManager;
+var world = workspace.world;
+var procedures = (function() {
+  var procs = {};
+  var temp = undefined;
+  temp = (function() {
+    try {
+      var reporterContext = false;
+      var letVars = { };
+      world.clearAll();
+      world.patches().ask(function() { SelfManager.self().setPatchVariable("pcolor", ListPrims.oneOf([15, 55, 105, 0])); }, true);
+      world.ticker.reset();
+    } catch (e) {
+      if (e instanceof Exception.StopInterrupt) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["setup"] = temp;
+  procs["SETUP"] = temp;
+  temp = (function() {
+    try {
+      var reporterContext = false;
+      var letVars = { };
+      let swapEvent = 0; letVars['swapEvent'] = swapEvent;
+      let reproduceEvent = 1; letVars['reproduceEvent'] = reproduceEvent;
+      let selectEvent = 2; letVars['selectEvent'] = selectEvent;
+      let repetitions = Prims.div(world.patches().size(), 3); letVars['repetitions'] = repetitions;
+      let events = ListPrims.shuffle(ListPrims.sentence(Tasks.nValues(Prims.randomPoisson((repetitions * procedures["SWAP-RATE"]())), Tasks.reporterTask(function() { return swapEvent; }, "[ swap-event ]")), Tasks.nValues(Prims.randomPoisson((repetitions * procedures["REPRODUCE-RATE"]())), Tasks.reporterTask(function() { return reproduceEvent; }, "[ reproduce-event ]")), Tasks.nValues(Prims.randomPoisson((repetitions * procedures["SELECT-RATE"]())), Tasks.reporterTask(function() { return selectEvent; }, "[ select-event ]")))); letVars['events'] = events;
+      var _foreach_1684_1691 = Tasks.forEach(Tasks.commandTask(function(_event_) {
+        if (arguments.length < 1) {
+          throw new Error("anonymous procedure expected 1 input, but only got " + arguments.length);
+        }
+        ListPrims.oneOf(world.patches()).ask(function() {
+          let target = ListPrims.oneOf(SelfManager.self().getNeighbors4()); letVars['target'] = target;
+          if (Prims.equality(_event_, swapEvent)) {
+            procedures["SWAP"](target);
+          }
+          if (Prims.equality(_event_, reproduceEvent)) {
+            procedures["REPRODUCE"](target);
+          }
+          if (Prims.equality(_event_, selectEvent)) {
+            procedures["SELECT"](target);
+          }
+        }, true);
+      }, "[ event -> ask one-of patches [ let one-of neighbors4 if event = swap-event [ swap target ] if event = reproduce-event [ reproduce target ] if event = select-event [ select target ] ] ]"), events); if(reporterContext && _foreach_1684_1691 !== undefined) { return _foreach_1684_1691; }
+      world.ticker.tick();
+    } catch (e) {
+      if (e instanceof Exception.StopInterrupt) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["go"] = temp;
+  procs["GO"] = temp;
+  temp = (function(target) {
+    try {
+      var reporterContext = false;
+      var letVars = { };
+      let oldColor = SelfManager.self().getPatchVariable("pcolor"); letVars['oldColor'] = oldColor;
+      SelfManager.self().setPatchVariable("pcolor", target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }));
+      target.ask(function() { SelfManager.self().setPatchVariable("pcolor", oldColor); }, true);
+    } catch (e) {
+      if (e instanceof Exception.StopInterrupt) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["swap"] = temp;
+  procs["SWAP"] = temp;
+  temp = (function(target) {
+    try {
+      var reporterContext = false;
+      var letVars = { };
+      if (procedures["BEAT?"](target)) {
+        target.ask(function() { SelfManager.self().setPatchVariable("pcolor", 0); }, true);
+      }
+      else {
+        if (target.projectionBy(function() { return procedures["BEAT?"](SelfManager.myself()); })) {
+          SelfManager.self().setPatchVariable("pcolor", 0);
+        }
+      }
+    } catch (e) {
+      if (e instanceof Exception.StopInterrupt) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["select"] = temp;
+  procs["SELECT"] = temp;
+  temp = (function(target) {
+    try {
+      var reporterContext = false;
+      var letVars = { };
+      if (Prims.equality(target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }), 0)) {
+        target.ask(function() {
+          SelfManager.self().setPatchVariable("pcolor", SelfManager.myself().projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }));
+        }, true);
+      }
+      else {
+        if (Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 0)) {
+          SelfManager.self().setPatchVariable("pcolor", target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }));
+        }
+      }
+    } catch (e) {
+      if (e instanceof Exception.StopInterrupt) {
+        return e;
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["reproduce"] = temp;
+  procs["REPRODUCE"] = temp;
+  temp = (function(target) {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return (((Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 15) && Prims.equality(target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }), 55)) || (Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 55) && Prims.equality(target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }), 105))) || (Prims.equality(SelfManager.self().getPatchVariable("pcolor"), 105) && Prims.equality(target.projectionBy(function() { return SelfManager.self().getPatchVariable("pcolor"); }), 15)))
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["beat_p"] = temp;
+  procs["BEAT?"] = temp;
+  temp = (function(exponent) {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return NLMath.pow(10, exponent)
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["rateFromExponent"] = temp;
+  procs["RATE-FROM-EXPONENT"] = temp;
+  temp = (function() {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return procedures["RATE-FROM-EXPONENT"](world.observer.getGlobal("swap-rate-exponent"))
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["swapRate"] = temp;
+  procs["SWAP-RATE"] = temp;
+  temp = (function() {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return procedures["RATE-FROM-EXPONENT"](world.observer.getGlobal("reproduce-rate-exponent"))
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["reproduceRate"] = temp;
+  procs["REPRODUCE-RATE"] = temp;
+  temp = (function() {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return procedures["RATE-FROM-EXPONENT"](world.observer.getGlobal("select-rate-exponent"))
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["selectRate"] = temp;
+  procs["SELECT-RATE"] = temp;
+  temp = (function(rate) {
+    try {
+      var reporterContext = true;
+      var letVars = { };
+      if(!reporterContext) { throw new Error("REPORT can only be used inside TO-REPORT.") } else {
+        return Prims.div((100 * rate), ((procedures["SWAP-RATE"]() + procedures["REPRODUCE-RATE"]()) + procedures["SELECT-RATE"]()))
+      }
+      throw new Error("Reached end of reporter procedure without REPORT being called.");
+    } catch (e) {
+     if (e instanceof Exception.StopInterrupt) {
+        throw new Error("STOP is not allowed inside TO-REPORT.");
+      } else {
+        throw e;
+      }
+    }
+  });
+  procs["percentage"] = temp;
+  procs["PERCENTAGE"] = temp;
+  return procs;
+})();
+world.observer.setGlobal("swap-rate-exponent", 0);
+world.observer.setGlobal("reproduce-rate-exponent", 0);
+world.observer.setGlobal("select-rate-exponent", 0);


### PR DESCRIPTION
@qiemem reported the Rock Paper Scissors library model performed poorly in NetLogo Web.  In checking, it was an issue with the `one-of` primitive being used in combination with large agent sets, specifically a large world patch set.  The improvements should help speed up any model that uses `one-of` with agent sets, and especially so with larger agent-sets.

These changes have been reviewed by @TheBizzle already, I just wanted a place to post the optimization results for RPS.  Qualitatively the model is also much more usable with the changes.  Other model benchmarks showed no change, or more modest improvements.

```
Time:       08/09/2018 @ 12:40:00 PM CDT
Version:    e50ad8c-dirty
Models:     Rock Paper Scissors
Iterations: 20
Ticks:      200
Engines:    V8
Comment:    `one-of` pre-optimizations

Rock Paper Scissors (V8 Node.js v9.7.1):
--Average: 446.356 seconds
--Min:     439.326 seconds
--Max:     452.935 seconds

==========

Time:       08/09/2018 @ 12:22:52 PM CDT
Version:    8f627a5-dirty
Models:     Rock Paper Scissors
Iterations: 20
Ticks:      200
Engines:    V8
Comment:    `one-of` post-optimizations

Rock Paper Scissors (V8 Node.js v9.7.1):
--Average: 26.993 seconds
--Min:     26.285 seconds
--Max:     27.482 seconds
```
