### PR TITLE
Add Table Extension

### DIFF
--- a/engine/src/main/coffee/extensions/all.coffee
+++ b/engine/src/main/coffee/extensions/all.coffee
@@ -1,6 +1,6 @@
 # (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
 
-extensionPaths = ['array', 'codap', 'encode', 'dialog', 'export-the', 'fetch', 'http-req', 'import-a', 'logging', 'matrix', 'mini-csv', 'nlmap', 'nt', 'send-to', 'store']
+extensionPaths = ['array', 'codap', 'encode', 'dialog', 'export-the', 'fetch', 'http-req', 'import-a', 'logging', 'matrix', 'mini-csv', 'nlmap', 'nt', 'send-to', 'store', 'table']
 
 dumpers = extensionPaths.map((path) -> require("extensions/#{path}").dumper).filter((x) -> x?)
 

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -2,7 +2,7 @@
 
 # (Any) => Boolean
 isTable = (x) ->
-  x.type = "table"
+  x instanceof Map
 
 # (Table) => String
 dumpTable = (table) ->
@@ -131,6 +131,7 @@ module.exports = {
       ,         "REMOVE": remove
       ,        "TO-LIST": toList
       ,         "VALUES": values
+      ,      "IS-TABLE?": isTable
       }
     }
 

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -106,12 +106,21 @@ module.exports = {
       else
         defaultValue
 
-    groupAgents = () ->
+    # (Agentset, Reporter) => Table
+    groupAgents = (agentset, reporter) ->
       return
 
+    # (List, (Number => Number)) => Table
+    groupItems = (list, reporter) ->
+      group = new Map()
 
-    groupItems = () ->
-      return
+      for item in list
+        key = Array.from(group.keys()).find((k) -> equals(k, reporter(item))) ? reporter(item)
+        value = group.get(key) ? []
+        value.push(item)
+        group.set(key, value)
+
+      group
 
     {
       name: "table"

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -41,26 +41,29 @@ module.exports = {
 
     # (Table, Any) => Any
     get = (table, key) ->
-      if key instanceof Array
-        if key = Array.from(table.keys()).find((k) -> equals(k, key))
-          table.get(key)
+      if key not instanceof Array
+        return table.get(key)
+
+      origin_key = Array.from(table.keys()).find((k) -> equals(k, key))
+      if origin_key?
+        table.get(origin_key)
       else
-        table.get(key)
+        throw new Error("Extension Exception: No value for #{key} in table.")
 
     # (Table, Any) => Boolean
     hasKey = (table, key) ->
-      if key instanceof Array
-        Array.from(table.keys()).some((k) -> equals(k, key))
-      else
-        table.has(key)
+      if key not instanceof Array
+        return table.has(key)
+
+      Array.from(table.keys()).some((k) -> equals(k, key))
 
     # (Table) => List
     keys = (table) ->
-      Array.from(table.keys())
+      Array.from(table.keys()).slice(0)
 
     # (Table) => List
     values = (table) ->
-      Array.from(table.values())
+      Array.from(table.values()).slice(0)
 
     # (Table) => Number
     length = (table) ->
@@ -93,9 +96,9 @@ module.exports = {
     counts = (list) ->
       counts = new Map()
 
-      for key in list
-        count = if hasKey(counts, key) then get(counts, key) + 1 else 1
-        put(counts, key, count)
+      for item in list
+        count = if hasKey(counts, item) then get(counts, item) + 1 else 1
+        put(counts, item, count)
 
       counts
 

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -161,7 +161,25 @@ module.exports = {
 
     # (Agentset, Reporter) => Table
     groupAgents = (agentset, reporter) ->
-      return
+      group = new Map()
+
+      agentset.shufflerator().forEach( (agent) ->
+        key = workspace.world.selfManager.askAgent(reporter)(agent)
+        value = group.get(key) ? []
+        value.push(agent)
+        group.set(key, value)
+      )
+
+      group.forEach( (value, key, map) ->
+        newAgentset = switch agentset._agentTypeName
+          when "turtles" then new TurtleSet(value, workspace.world)
+          when "patches" then new PatchSet(value, workspace.world)
+          when "links"   then new LinkSet(value, workspace.world)
+          else throw new Error("Unknown agentset type")
+        group.set(key, newAgentset)
+      )
+
+      group
 
     # (List, (Number => Number)) => Table
     groupItems = (list, reporter) ->

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -1,0 +1,89 @@
+# (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
+
+# (Any) => Boolean
+isTable = (x) ->
+  x.type = "table"
+
+module.exports = {
+
+  dumper: { canDump: isTable, dump: (x) -> "{{table: [#{Array.from(x).map( (item) => workspace.dump(item, true) ).join(' ')}]}}" }
+
+  init: (workspace) ->
+
+    # () => Table
+    make = ->
+      new Map()
+
+    # (List) => Map
+    fromList = (list) ->
+      new Map(list.slice(0))
+
+    # (Table) => List
+    toList = (table) ->
+      Array.from(table).slice(0)
+
+    # (Table) => Unit
+    clear = (table) ->
+      table.clear()
+
+    # (Table, Any) => Any
+    get = (table, key) ->
+      table.get(key)
+
+    # (Table, Any) => Boolean
+    hasKey = (table, key) ->
+      table.has(key)
+
+    # (Table) => List
+    keys = (table) ->
+      Array.from(table.keys())
+
+    # (Table) => List
+    values = (table) ->
+      Array.from(table.values())
+
+    length = (table) ->
+      table.size
+
+    put = (table, key, value) ->
+      table.set(key, value)
+      return
+
+    remove = (table, key) ->
+      table.delete(key)
+      return
+
+    counts = () ->
+      return
+
+    groupAgents = () ->
+      return
+
+    groupItems = () ->
+      return
+
+    getOrDefault = () ->
+      return
+
+    {
+      name: "table"
+    , prims: {
+                 "CLEAR": clear
+      ,         "COUNTS": counts
+      ,   "GROUP-AGENTS": groupAgents
+      ,    "GROUP-ITEMS": groupItems
+      ,      "FROM-LIST": fromList
+      ,            "GET": get
+      , "GET-OR-DEFAULT": getOrDefault
+      ,       "HAS-KEY?": hasKey
+      ,           "KEYS": keys
+      ,         "LENGTH": length
+      ,           "MAKE": make
+      ,            "PUT": put
+      ,         "REMOVE": remove
+      ,        "TO-LIST": toList
+      ,         "VALUES": values
+      }
+    }
+
+}

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -85,9 +85,9 @@ module.exports = {
       if key not instanceof Array
         return table.get(key)
 
-      origin_key = getOriginKey(table, key)
-      if origin_key?
-        table.get(origin_key)
+      originKey = getOriginKey(table, key)
+      if originKey?
+        table.get(originKey)
       else
         throw new Error("Extension Exception: No value for #{key} in table.")
 
@@ -134,9 +134,9 @@ module.exports = {
         table.delete(key)
         return
 
-      origin_key = getOriginKey(table, key)
-      if origin_key?
-        table.delete(origin_key)
+      originKey = getOriginKey(table, key)
+      if originKey?
+        table.delete(originKey)
 
       return
 

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -170,12 +170,12 @@ module.exports = {
         group.set(key, value)
       )
 
-      group.forEach( (value, key, map) ->
+      group.forEach( (value, key) ->
         newAgentset = switch agentset._agentTypeName
           when "turtles" then new TurtleSet(value, workspace.world)
           when "patches" then new PatchSet(value, workspace.world)
           when "links"   then new LinkSet(value, workspace.world)
-          else throw new Error("Unknown agentset type")
+          else throw new Error("Extension Exception: Unknown agentset type")
         group.set(key, newAgentset)
       )
 

--- a/engine/src/main/coffee/extensions/table.coffee
+++ b/engine/src/main/coffee/extensions/table.coffee
@@ -42,7 +42,7 @@ checkIsValidList = (list) ->
       throw new Error("Extension Exception: expected a two-element list: #{workspace.dump(pair, true)}")
   return
 
-# (Any, String|Boolean|Number|List) -> Boolean
+# (Any, String|Boolean|Number|List) ->
 checkInput = ({table, key}) ->
   if not isTable(table)
     throw new Error("Extension Exception: not a table #{workspace.dump(table, true)}")

--- a/engine/src/main/coffee/extensions/table.json
+++ b/engine/src/main/coffee/extensions/table.json
@@ -2,6 +2,12 @@
   "name": "table",
   "prims": [
     {
+      "name": "is-table?",
+      "actionName": "is-table?",
+      "argTypes": ["wildcard"],
+      "returnType": "boolean"
+    },
+    {
       "name": "clear",
       "actionName": "clear",
       "argTypes": ["wildcard"],

--- a/engine/src/main/coffee/extensions/table.json
+++ b/engine/src/main/coffee/extensions/table.json
@@ -1,0 +1,81 @@
+{
+  "name": "table",
+  "prims": [
+    {
+      "name": "clear",
+      "actionName": "clear",
+      "argTypes": ["wildcard"],
+      "returnType": "unit"
+    }, {
+      "name": "counts",
+      "actionName": "counts",
+      "argTypes": ["list"],
+      "returnType": "wildcard"
+    }, {
+      "name": "group-agents",
+      "actionName": "group-agents",
+      "argTypes": ["agentset", "reporter"],
+      "returnType": "wildcard"
+    }, {
+      "name": "group-items",
+      "actionName": "group-items",
+      "argTypes": ["list", "reporter"],
+      "returnType": "wildcard"
+    }, {
+      "name": "from-list",
+      "actionName": "from-list",
+      "argTypes": ["list"],
+      "returnType": "wildcard"
+    }, {
+      "name": "get",
+      "actionName": "get",
+      "argTypes": ["wildcard", "wildcard"],
+      "returnType": "wildcard"
+    }, {
+      "name": "get-or-default",
+      "actionName": "get-or-default",
+      "argTypes": ["list", "wildcard", "wildcard"],
+      "returnType": "wildcard"
+    }, {
+      "name": "has-key?",
+      "actionName": "has-key?",
+      "argTypes": ["wildcard", "wildcard"],
+      "returnType": "boolean"
+    }, {
+      "name": "keys",
+      "actionName": "keys",
+      "argTypes": ["wildcard"],
+      "returnType": "list"
+    }, {
+      "name": "length",
+      "actionName": "length",
+      "argTypes": ["wildcard"],
+      "returnType": "number"
+    }, {
+      "name": "make",
+      "actionName": "make",
+      "argTypes": [],
+      "returnType": "wildcard"
+    }, {
+      "name": "put",
+      "actionName": "put",
+      "argTypes": ["wildcard", "wildcard", "wildcard"],
+      "returnType": "unit"
+    }, {
+      "name": "remove",
+      "actionName": "remove",
+      "argTypes": ["wildcard", "wildcard"],
+      "returnType": "unit"
+    }, {
+      "name": "to-list",
+      "actionName": "to-list",
+      "argTypes": ["wildcard"],
+      "returnType": "list"
+    }, {
+      "name": "values",
+      "actionName": "values",
+      "argTypes": ["wildcard"],
+      "returnType": "list"
+    }
+  ]
+}

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -15,6 +15,12 @@ TablesBasics
   O> table:clear glob1
   table:length glob1 => 0
 
+TableGet
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list [[[1 2] 1] [[3 4] 2]]
+  table:get glob1 [1 2] => 1
+
 TablesToFromList
   extensions [ table ]
   globals [glob1 glob2]
@@ -24,6 +30,8 @@ TablesToFromList
   table:get glob2 "key" => "value"
   table:get glob2 1 => 2
   glob1 = table:to-list glob2 => true
+  O> set glob1 table:make
+  table:to-list glob1 => []
 
 TablesOfTables
   extensions [ table ]
@@ -48,3 +56,41 @@ TableValues
   table:values t => ["a" -1 "testing values"]
   O> table:put t -1 -1
   table:values t => ["a" -1 "testing values" -1]
+
+TableHasKeys
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list [[[1] 1] [2 2]]
+  table:has-key? glob1 [2] => false
+  table:has-key? glob1 [1] => true
+  table:has-key? glob1 2 => true
+
+TableKeys
+  extensions [ table ]
+  globals [ t ]
+  O> set t table:make
+  table:keys t => []
+  O> table:put t 1 "a"
+  table:keys t => [1]
+  O> table:put t 2 "b"
+  table:keys t => [1 2]
+  O> table:put t list 1 2 -1
+  table:keys t => [1 2 [1 2]]
+  O> table:put t "testing values" "a"
+  table:keys t => [1 2 [1 2] "testing values"]
+  O> table:remove t [1 2]
+  table:keys t => [1 2 "testing values"]
+  O> table:put t -1 -1
+  table:keys t => [1 2 "testing values" -1]
+
+TableCounts
+  extensions [ table ]
+  globals [ ls glob1 ]
+  O> set ls [1 1 2 3 3]
+  (word table:counts ls) => "{{table: [[1 2] [2 1] [3 2]]}}"
+  (word table:counts ["a" 0 "a" 4 [5] [5]]) => "{{table: [[\"a\" 2] [0 1] [4 1] [[5] 2]]}}"
+
+TableGetOrDefault
+  extensions [ table ]
+  table:get-or-default (table:from-list [[1 2]]) 1 3 => 2
+  table:get-or-default (table:from-list [[1 2]]) 2 3 => 3

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -1,0 +1,50 @@
+TablesBasics
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:make
+  O> table:put glob1 0 "testvalue"
+  O> table:put glob1 "testkey" 1
+  table:length glob1 => 2
+  table:get glob1 "testkey" => 1
+  table:get glob1 0 => "testvalue"
+  table:keys glob1 => [0 "testkey"]
+  table:has-key? glob1 0 => true
+  table:has-key? glob1 3 => false
+  table:has-key? glob1 "testkey" => true
+  table:has-key? glob1 "somestring" => false
+  O> table:clear glob1
+  table:length glob1 => 0
+
+TablesToFromList
+  extensions [ table ]
+  globals [glob1 glob2]
+  O> set glob1 [[1 2] ["key" "value"]]
+  O> set glob2 table:from-list glob1
+  (word glob2) => "{{table: [[1 2] [\"key\" \"value\"]]}}"
+  table:get glob2 "key" => "value"
+  table:get glob2 1 => 2
+  glob1 = table:to-list glob2 => true
+
+TablesOfTables
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list ( list (list 0 table:from-list [[1 2] [3 4]]) )
+  (word glob1) => "{{table: [[0 {{table: [[1 2] [3 4]]}}]]}}"
+
+TableValues
+  extensions [ table ]
+  globals [ t ]
+  O> set t table:make
+  table:values t => []
+  O> table:put t 1 "a"
+  table:values t => ["a"]
+  O> table:put t 2 "b"
+  table:values t => ["a" "b"]
+  O> table:put t list 1 2 -1
+  table:values t => ["a" "b" -1]
+  O> table:put t "a" "testing values"
+  table:values t => ["a" "b" -1 "testing values"]
+  O> table:remove t 2
+  table:values t => ["a" -1 "testing values"]
+  O> table:put t -1 -1
+  table:values t => ["a" -1 "testing values" -1]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -117,8 +117,66 @@ TableGroupItems
   (word table:group-items range 10 [ n -> n mod 2 ]) => "{{table: [[0 [0 2 4 6 8]] [1 [1 3 5 7 9]]]}}"
   (word table:group-items [[1] [2] [3]] [ arr -> arr ]) => "{{table: [[[1] [[1]]] [[2] [[2]]] [[3] [[3]]]]}}"
 
-TableExceoption_isValidKey
+TableException_isTable
   extensions [ table ]
+  table:to-list [1] => ERROR Extension Exception: not a table [1]
+  O> table:clear [1] => ERROR Extension Exception: not a table [1]
+  table:get [1] 1 => ERROR Extension Exception: not a table [1]
+  table:has-key? [1] 1 => ERROR Extension Exception: not a table [1]
+  table:keys [] => ERROR Extension Exception: not a table []
+  table:values [] => ERROR Extension Exception: not a table []
+  table:length [[1]] => ERROR Extension Exception: not a table [[1]]
+  O> table:put [1 2 3] 1 1 => ERROR Extension Exception: not a table [1 2 3]
+  O> table:remove [1 2 3] 1 => ERROR Extension Exception: not a table [1 2 3]
+  table:get-or-default [1 2 3] 2 3 => ERROR Extension Exception: not a table [1 2 3]
+
+TableException_isValidList
+  extensions [ table ]
+  table:from-list [[1]] => ERROR Extension Exception: expected a two-element list: [1]
+
+TableException_isValidKey
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list [[1 1]]
+  O> table:put glob1 [n -> n] 1 => ERROR Extension Exception: (anonymous reporter: [ n -> n ]) is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+
+TablesAllowableTypes
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:make
+  O> table:put glob1 0 "number"
+  O> table:put glob1 "foo" "string"
+  O> table:put glob1 true "boolean"
+  O> table:put glob1 false "boolean"
+  O> table:put glob1 nobody "nobody" => ERROR Extension Exception: nobody is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> table:put glob1 turtles "turtle set" => ERROR Extension Exception: turtles is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> table:put glob1 patches "patch set" => ERROR Extension Exception: patches is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> table:put glob1 links "link set" => ERROR Extension Exception: links is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> table:put glob1 turtle 0 "nonexistent turtle" => ERROR Extension Exception: nobody is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> crt 1
+  O> table:put glob1 turtle 0 "turtle" => ERROR Extension Exception: (turtle 0) is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> ct
+  O> table:put glob1 turtle 0 "dead turtle" => ERROR Extension Exception: nobody is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+  O> table:put glob1 [] "list"
+  O> table:put glob1 [1] "1"
+  O> table:put glob1 [1] "2"
+  table:get glob1 [1] => "2"
+  O> table:put glob1 [[1] ["two" "three"] [4]] "uh huh"
+  table:get glob1 [[1] ["two" "three"] [4]] => "uh huh"
+
+TablesAllowableTypes_2D
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:make
+  O> crt 1
+  O> table:put glob1 [patch-here] of turtle 0 "patch" => ERROR Extension Exception: (patch 0 0) is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
+
+TablesAllowableTypes_3D
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:make
+  O> crt 1
+  O> table:put glob1 patch 0 0 0 "patch" => ERROR Extension Exception: (patch 0 0 0) is not a valid table key (a table key may only be a number, a string, true or false, or a list whose items are valid keys)
 
 TableDoesNotLeak
   extensions [ table ]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -117,6 +117,17 @@ TableGroupItems
   (word table:group-items range 10 [ n -> n mod 2 ]) => "{{table: [[0 [0 2 4 6 8]] [1 [1 3 5 7 9]]]}}"
   (word table:group-items [[1] [2] [3]] [ arr -> arr ]) => "{{table: [[[1] [[1]]] [[2] [[2]]] [[3] [[3]]]]}}"
 
+TableGroupAgents
+  extensions [ table ]
+  globals [ t ]
+  O> crt 3 [ set color red ]
+  O> crt 4 [ set color green ]
+  O> crt 5 [ set color blue ]
+  O> set t table:group-agents turtles [ color ]
+  count table:get t red => 3
+  count table:get t green => 4
+  count table:get t blue => 5
+
 TableException_isTable
   extensions [ table ]
   table:to-list [1] => ERROR Extension Exception: not a table [1]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -76,10 +76,11 @@ TableValues
 TableHasKeys
   extensions [ table ]
   globals [glob1]
-  O> set glob1 table:from-list [[[1] 1] [2 2]]
+  O> set glob1 table:from-list [[[1] 1] [2 2] [0 0]]
   table:has-key? glob1 [2] => false
   table:has-key? glob1 [1] => true
   table:has-key? glob1 2 => true
+  table:has-key? glob1 0 => true
 
 TableKeys
   extensions [ table ]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -37,6 +37,12 @@ TablesToFromList
   O> set glob1 table:make
   table:to-list glob1 => []
 
+Table_dumpTable
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list [[1 1] [[2 2] [2 2]] ["3" "3"] [true true]]
+  (word glob1) => "{{table: [[1 1] [[2 2] [2 2]] [\"3\" \"3\"] [true true]]}}"
+
 TableGet
   extensions [ table ]
   globals [glob1]
@@ -109,3 +115,19 @@ TableGroupItems
   extensions [ table ]
   (word table:group-items range 10 [ n -> n mod 2 ]) => "{{table: [[0 [0 2 4 6 8]] [1 [1 3 5 7 9]]]}}"
   (word table:group-items [[1] [2] [3]] [ arr -> arr ]) => "{{table: [[[1] [[1]]] [[2] [[2]]] [[3] [[3]]]]}}"
+
+TableExceoption_isValidKey
+  extensions [ table ]
+
+TableDoesNotLeak
+  extensions [ table ]
+  globals [ls glob1]
+  O> set ls [[1 1] [2 2]]
+  O> set glob1 table:from-list ls
+  O> table:put glob1 3 3
+  table:to-list glob1 => [[1 1] [2 2] [3 3]]
+  ls => [[1 1] [2 2]]
+  O> set ls table:to-list glob1
+  O> table:remove glob1 3
+  table:to-list glob1 => [[1 1] [2 2]]
+  ls => [[1 1] [2 2] [3 3]]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -1,7 +1,17 @@
+Table_isTable
+  extensions [ table ]
+  globals [glob1]
+  table:is-table? 0 => false
+  table:is-table? [1 2 3] => false
+  table:is-table? "hello" => false
+  table:is-table? table:make => true
+  table:is-table? table:to-list table:make => false
+
 TablesBasics
   extensions [ table ]
   globals [glob1]
   O> set glob1 table:make
+  (word glob1) => "{{table: []}}"
   O> table:put glob1 0 "testvalue"
   O> table:put glob1 "testkey" 1
   table:length glob1 => 2
@@ -15,12 +25,6 @@ TablesBasics
   O> table:clear glob1
   table:length glob1 => 0
 
-TableGet
-  extensions [ table ]
-  globals [glob1]
-  O> set glob1 table:from-list [[[1 2] 1] [[3 4] 2]]
-  table:get glob1 [1 2] => 1
-
 TablesToFromList
   extensions [ table ]
   globals [glob1 glob2]
@@ -32,6 +36,12 @@ TablesToFromList
   glob1 = table:to-list glob2 => true
   O> set glob1 table:make
   table:to-list glob1 => []
+
+TableGet
+  extensions [ table ]
+  globals [glob1]
+  O> set glob1 table:from-list [[[1 2] 1] [[3 4] 2]]
+  table:get glob1 [1 2] => 1
 
 TablesOfTables
   extensions [ table ]

--- a/resources/test/commands/Table.txt
+++ b/resources/test/commands/Table.txt
@@ -104,3 +104,8 @@ TableGetOrDefault
   extensions [ table ]
   table:get-or-default (table:from-list [[1 2]]) 1 3 => 2
   table:get-or-default (table:from-list [[1 2]]) 2 3 => 3
+
+TableGroupItems
+  extensions [ table ]
+  (word table:group-items range 10 [ n -> n mod 2 ]) => "{{table: [[0 [0 2 4 6 8]] [1 [1 3 5 7 9]]]}}"
+  (word table:group-items [[1] [2] [3]] [ arr -> arr ]) => "{{table: [[[1] [[1]]] [[2] [[2]]] [[3] [[3]]]]}}"


### PR DESCRIPTION
This PR is the table extension.

Following is the summary of what I've done in this PR
- Align all APIs with desktop's table extension
- Have the same input type checkings and exceptions with desktop
- Add thorough tests, including all tests from desktop's [Table-Extension](https://github.com/NetLogo/Table-Extension/blob/hexy/tests.txt), except for TablesEquality tests

I didn't implement `groupAgents()` API. I got stuck on implementing it and would be appreciated if I can get an idea or information.

I've got some observations. 
I noticed that `groupAgents()` means to group agents by their attributes, like `color`, `xcor`, `size`...
After I `console.log(reporter)`, I found it's an anonymous function 
```
() { return SelfManager.self().getVariable("color"); }
```

I guess `SelfManager.self()` need to be replaced by `agent`. But I don't know how. I was confused about how to write js to implement something like `[color] of turtles`.

#### Other Notes
I didn't add `TableEquality` tests that are about to compare extensions objects. I'd like to open a new PR to implement this feature on table, matrix, array ...