### PR TITLE
Add small API for introspecting compilation results

### DIFF
--- a/compiler/js/src/main/scala/BrowserCompiler.scala
+++ b/compiler/js/src/main/scala/BrowserCompiler.scala
@@ -2,38 +2,33 @@
 
 package org.nlogo.tortoise.compiler
 
-import
-  CompiledModel.CompileResult
+import CompiledModel.CompileResult
 
-import
-  json.{ JsonLibrary, JsonReader, JsonWritable, JsonWriter, TortoiseJson },
-    JsonLibrary.{ Native => NativeJson, toTortoise },
-    JsonWriter.string2TortoiseJs,
-    TortoiseJson._
+import json.JsonLibrary
+import json.JsonLibrary.{ Native => NativeJson, toTortoise }
+import json.JsonReader
+import json.JsonWritable
+import json.JsonWriter
+import json.JsonWriter.string2TortoiseJs
+import json.TortoiseJson
+import json.TortoiseJson._
 
-import
-  org.nlogo.tortoise.macros.json.Jsonify
+import org.nlogo.tortoise.macros.json.Jsonify
 
-import
-  org.nlogo.core.{ CompilerException, model },
-    model.ModelReader
+import org.nlogo.core.CompilerException
+import org.nlogo.core.model.ModelReader
 
 import org.nlogo.parse.CompilerUtilities
 
-import
-  scala.reflect.ClassTag
+import scala.reflect.ClassTag
 
-import
-  scala.scalajs.js
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{ JSExport, JSExportTopLevel }
 
-import
-  scala.scalajs.js.annotation.{ JSExport, JSExportTopLevel }
-
-import
-  scalaz.{ NonEmptyList, Scalaz, std, Validation, ValidationNel },
-    std.list._,
-    Scalaz.ToValidationOps,
-    Validation.FlatMap.ValidationFlatMapRequested
+import scalaz.{ NonEmptyList, Validation, ValidationNel }
+import scalaz.std.list._
+import scalaz.Scalaz.ToValidationOps
+import scalaz.Validation.FlatMap.ValidationFlatMapRequested
 
 @JSExportTopLevel("BrowserCompiler")
 class BrowserCompiler {

--- a/compiler/js/src/main/scala/BrowserCompiler.scala
+++ b/compiler/js/src/main/scala/BrowserCompiler.scala
@@ -20,6 +20,7 @@ import org.nlogo.core.model.ModelReader
 
 import org.nlogo.parse.CompilerUtilities
 
+import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
 
 import scala.scalajs.js
@@ -124,6 +125,63 @@ class BrowserCompiler {
     val overridingSeq: Seq[String] = overriding.map(_.toUpperCase)
     val results: CompiledStringV   = lastCompiledModel.compileProceduresIncremental(command, overridingSeq)
     JsonLibrary.toNative(compileResult2Json.apply(results))
+  }
+
+  @JSExport
+  def listGlobalVars(): NativeJson = {
+
+    val program     = lastCompiledModel.compilation.program
+    val interfaceGs = program.interfaceGlobals.map((g) => (g,               "interface"))
+    val      userGs = program.     userGlobals.map((g) => (g.toLowerCase,        "user"))
+
+    val json =
+      JsArray(
+        (interfaceGs ++ userGs).map {
+          case (name, typ) =>
+            JsObject(
+              ListMap( "name" -> JsString(name)
+                     , "type" -> JsString(typ)
+                     )
+            )
+        }
+      )
+
+    JsonLibrary.toNative(json)
+
+  }
+
+  @JSExport
+  def listProcedures(): NativeJson = {
+
+    val procedures = lastCompiledModel.compilation.procedures.values
+
+    val json =
+      JsArray(
+        procedures.map(
+          (proc) =>
+            JsObject(
+              ListMap( "argCount"            -> JsInt   (proc.argTokens.length)
+                     , "isReporter"          -> JsBool  (proc.isReporter)
+                     , "isUseableByObserver" -> JsBool  (proc.agentClassString(0) == 'O')
+                     , "isUseableByTurtles"  -> JsBool  (proc.agentClassString(1) == 'T')
+                     , "name"                -> JsString(proc.name.toLowerCase)
+                     )
+            )
+        ).toSeq
+      )
+
+    JsonLibrary.toNative(json)
+
+  }
+
+  @JSExport
+  def listVarsForBreed(breedName: String): NativeJson = {
+    val program    = lastCompiledModel.compilation.program
+    val commonVars = program.turtleVars.keys
+    val breedVars  = program.breeds.get(breedName.toUpperCase).fold(Seq[String]())(_.owns)
+    val jsonify    = ((x: String) => x.toLowerCase) andThen JsString.apply
+    val json       = JsArray((commonVars ++ breedVars).map(jsonify).toSeq)
+    JsonLibrary.toNative(json)
   }
 
   private def transformErrorsAndUpdateModel(

--- a/compiler/shared/src/main/scala/JsOps.scala
+++ b/compiler/shared/src/main/scala/JsOps.scala
@@ -2,6 +2,11 @@
 
 package org.nlogo.tortoise.compiler
 
+// All of these type casts to `StringOps` are a workaround for dealing with
+// this: https://github.com/scala/bug/issues/11125
+// --JAB (4/10/20)
+import scala.collection.immutable.StringOps
+
 object JsOps {
   // Intended to take in a NetLogo identifier (e.g. breed names, varnames, `turtles-own` varnames) and give back a
   // string for use in JavaScript.  We cannot simply wrap the string in single quotes, since single quotes are
@@ -29,7 +34,7 @@ object JsOps {
     val jsArgs = args.mkString("(", ", ", ")")
     if (body.length == 0)
       s"function$jsArgs {}"
-    else if (body.lines.length < 2 && body.length < 100)
+    else if ((body: StringOps).lines.length < 2 && body.length < 100)
       s"function$jsArgs { $body }"
     else
       s"""|function$jsArgs {
@@ -44,5 +49,5 @@ object JsOps {
     if (str.nonEmpty) jsFunction(body = s"return $str;") else jsFunction()
 
   def indented(s: String): String =
-    s.lines.map("  " + _).mkString("\n")
+    (s: StringOps).lines.map("  " + _).mkString("\n")
 }

--- a/netlogo-web/src/test/scala/dock/TestModels.scala
+++ b/netlogo-web/src/test/scala/dock/TestModels.scala
@@ -128,7 +128,7 @@ class TestModels extends DockingSuite {
 
     // Just check the patch size (not the image base64) --JAB (2/12/19)
     val transformDrawing =
-      (str: String) => str.lines.toSeq.init.mkString("\n")
+      (str: String) => (str: scala.collection.immutable.StringOps).lines.toSeq.init.mkString("\n")
 
     // Trim off plot bounds --JAB (1/3/18)
     val transformPlots =


### PR DESCRIPTION
@LaCuneta, you mentioned that you'd find this sort of thing useful for NetTango, so I wanted to run the API by you before merging it into `master`.

It is as follows:

> #### `BrowserCompiler.listGlobalVars`
>
> Returns: `Array[{ name: String_AnyCase, type: "interface" | "user" }]`
>
> #### `BrowserCompiler.listProcedures`
>
> Returns: `Array[{ argCount: Int, isReporter: Boolean, isUseableByObserver: Boolean, isUseableByTurtles: Boolean, name: String_LowerCase }]`
>
> #### `BrowserCompiler.listVarsForBreed(String_AnyCase)`
>
> Returns: `Array[String_LowerCase]`
>
> (Includes built-ins, like `who` and `size`)

Let me know if you would like to see any changes made. :sunglasses: 