### PR TITLE
Encode extension: Use UTF-8 encodings, not UTF-16 ones

### DIFF
--- a/engine/src/main/coffee/extensions/encode.coffee
+++ b/engine/src/main/coffee/extensions/encode.coffee
@@ -8,6 +8,9 @@
 { pipeline }   = require('brazier/function')
 { rangeUntil } = require('brazier/number')
 
+decoder = new TextDecoder()
+encoder = new TextEncoder()
+
 module.exports = {
 
   init: (workspace) ->
@@ -33,11 +36,11 @@ module.exports = {
 
     # Array[Number] => String
     bytesToString = (bytes) ->
-      _reportFromBytes(bytes, "bytes-to-string")((bytes) -> String.fromCharCode(bytes...))
+      _reportFromBytes(bytes, "bytes-to-string")((bytes) -> decoder.decode(new Uint8Array(bytes)))
 
     # (String) => Array[Number]
     stringToBytes = (str) ->
-      pipeline(rangeUntil(0), map((n) -> str.codePointAt(n)))(str.length)
+      Array.from(encoder.encode(str))
 
     {
       name: "encode"

--- a/resources/test/commands/Encode.txt
+++ b/resources/test/commands/Encode.txt
@@ -11,6 +11,9 @@ BytesAndStrings
   encode:bytes-to-string [10 20 30 -201 40] => ERROR Extension exception: All elements of the list argument to 'encode:bytes-to-string' must be numbers between -128 and 127
   encode:bytes-to-string [10 20 30 201 40] => ERROR Extension exception: All elements of the list argument to 'encode:bytes-to-string' must be numbers between -128 and 127
 
+  encode:string-to-bytes "My fav UTF-8 char: „" => [77 121 32 102 97 118 32 85 84 70 45 56 32 99 104 97 114 58 32 -30 -128 -98]
+  encode:bytes-to-string (encode:string-to-bytes "My fav UTF-8 char: „") => "My fav UTF-8 char: „"
+
   encode:string-to-bytes (encode:bytes-to-string [89 79 85 39 82 69 32 87 73 78 78 69 82 33]) => [89 79 85 39 82 69 32 87 73 78 78 69 82 33]
   encode:bytes-to-string (encode:string-to-bytes (encode:bytes-to-string [89 79 85 39 82 69 32 87 73 78 78 69 82 33])) => "YOU'RE WINNER!"
 

--- a/resources/test/polyfills.js
+++ b/resources/test/polyfills.js
@@ -193,6 +193,64 @@ if (typeof Polyglot !== "undefined") {
     return Base64.getEncoder().encodeToString(Compiler.getBytes(str));
   }
 
+  global.TextDecoder = class {
+    decode(bytes) {
+
+      // http://www.onicos.com/staff/iz/amuse/javascript/expert/utf.txt
+
+      /* utf.js - UTF-8 <=> UTF-16 convertion
+       *
+       * Copyright (C) 1999 Masanao Izumo <iz@onicos.co.jp>
+       * Version: 1.0
+       * This library is free.  You can redistribute it and/or modify it.
+       */
+
+      let out = "";
+      let i   = 0;
+
+      while (i < bytes.length) {
+
+        const char1 = bytes[i++];
+
+        switch (char1 >> 4) {
+          case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7: {
+            // 0xxxxxxx
+            out += String.fromCharCode(char1);
+            break;
+          }
+          case 12: case 13: {
+            // 110x xxxx   10xx xxxx
+            const char2 = bytes[i++];
+            const code  = ((char1 & 0x1F) << 6) |
+                          ((char2 & 0x3F) << 0)
+            out += String.fromCharCode(code);
+            break;
+          }
+          case 14: {
+            // 1110 xxxx  10xx xxxx  10xx xxxx
+            const char2 = bytes[i++];
+            const char3 = bytes[i++];
+            const code  = ((char1 & 0x0F) << 12) |
+                          ((char2 & 0x3F) <<  6) |
+                          ((char3 & 0x3F) <<  0)
+            out += String.fromCharCode(code);
+            break;
+          }
+        }
+
+      }
+
+      return out;
+
+    }
+  }
+
+  global.TextEncoder = class {
+    encode(str) {
+      return Compiler.getBytes(str);
+    }
+  }
+
   global.modelConfig =
     { asyncDialog:       asyncDialog
     , base64ToImageData: base64ToImageData


### PR DESCRIPTION
This is a PR to fix #229.  I'm seeking review mainly because I don't feel amazing about my polyfill for `TextDecoder.decode`.  Let me know you would like something else done with that.