### PR TITLE
Refactor: The Variable Manager

### DIFF
--- a/engine/src/main/coffee/engine/core/breedmanager.coffee
+++ b/engine/src/main/coffee/engine/core/breedmanager.coffee
@@ -80,8 +80,8 @@ module.exports =
     constructor: (breedObjs, turtlesOwns = [], linksOwns = []) ->
 
       defaultBreeds = {
-        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, [], undefined, "default"),
-        LINKS:   new Breed("links",   "link",   this, linksOwns,   [], false,     "default")
+        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, turtleBuiltins, undefined, "default"),
+        LINKS:   new Breed("links",   "link",   this, linksOwns,   linkBuiltins,   false,     "default")
       }
 
       @_breeds = foldl(

--- a/engine/src/main/coffee/engine/core/breedmanager.coffee
+++ b/engine/src/main/coffee/engine/core/breedmanager.coffee
@@ -3,6 +3,7 @@
 { foldl, isEmpty, last, map, sortedIndexBy, toObject } = require('brazierjs/array')
 { pipeline                                           } = require('brazierjs/function')
 { values                                             } = require('brazierjs/object')
+{ linkBuiltins, turtleBuiltins                       } = require('./structure/builtins')
 
 count = 0
 getNextOrdinal = -> count++
@@ -11,11 +12,13 @@ class Breed
 
   ordinal: undefined # Number
 
+  # By caching the variable list here, we prevent frequent re-concat of the two lists -- John Chen May 2023
   # (String, String, BreedManager, Array[String], Boolean, String, Array[Agent]) => Breed
-  constructor: (@originalName, @originalSingular, @_manager, @varNames = [], @_isDirectedLinkBreed, @_shape = undefined, @members = []) ->
+  constructor: (@originalName, @originalSingular, @_manager, @varNames = [], defaultVarNames = [], @_isDirectedLinkBreed, @_shape = undefined, @members = []) ->
     @name     = @originalName.toUpperCase()
     @singular = @originalSingular.toLowerCase()
     @ordinal  = getNextOrdinal()
+    @allVarNames = @varNames.concat(defaultVarNames)
 
   # We can't just set this in the constructor, because people can swoop into the manager and change the turtles'
   # default shape --JAB (5/27/14)
@@ -77,14 +80,15 @@ module.exports =
     constructor: (breedObjs, turtlesOwns = [], linksOwns = []) ->
 
       defaultBreeds = {
-        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, undefined, "default"),
-        LINKS:   new Breed("links",   "link",   this, linksOwns,   false,     "default")
+        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, [], undefined, "default"),
+        LINKS:   new Breed("links",   "link",   this, linksOwns,   [], false,     "default")
       }
 
       @_breeds = foldl(
         (acc, breedObj) =>
           trueVarNames    = breedObj.varNames ? []
-          breed           = new Breed(breedObj.name, breedObj.singular, this, trueVarNames, breedObj.isDirected)
+          defaultNames    = if breedObj.isDirected? then linksOwns.concat(linkBuiltins) else turtlesOwns.concat(turtleBuiltins)
+          breed           = new Breed(breedObj.name, breedObj.singular, this, trueVarNames, defaultNames, breedObj.isDirected)
           acc[breed.name] = breed
           acc
       )(defaultBreeds)(breedObjs)

--- a/engine/src/main/coffee/engine/core/breedmanager.coffee
+++ b/engine/src/main/coffee/engine/core/breedmanager.coffee
@@ -14,11 +14,12 @@ class Breed
 
   # By caching the variable list here, we prevent frequent re-concat of the two lists -- John Chen May 2023
   # (String, String, BreedManager, Array[String], Boolean, String, Array[Agent]) => Breed
-  constructor: (@originalName, @originalSingular, @_manager, @varNames = [], defaultVarNames = [], @_isDirectedLinkBreed, @_shape = undefined, @members = []) ->
+  constructor: (@originalName, @originalSingular, @_manager, @varNames = [], @defaultVarNames = [], @_isDirectedLinkBreed, @_shape = undefined, @members = []) ->
     @name     = @originalName.toUpperCase()
     @singular = @originalSingular.toLowerCase()
     @ordinal  = getNextOrdinal()
-    @allVarNames = @varNames.concat(defaultVarNames)
+    @customVarNames = @varNames.concat(@defaultVarNames)
+    @allVarNames = @varNames.concat(@defaultVarNames).concat(@_isDirectedLinkBreed? ? linkBuiltins : turtleBuiltins)
 
   # We can't just set this in the constructor, because people can swoop into the manager and change the turtles'
   # default shape --JAB (5/27/14)
@@ -80,14 +81,14 @@ module.exports =
     constructor: (breedObjs, turtlesOwns = [], linksOwns = []) ->
 
       defaultBreeds = {
-        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, turtleBuiltins, undefined, "default"),
-        LINKS:   new Breed("links",   "link",   this, linksOwns,   linkBuiltins,   false,     "default")
+        TURTLES: new Breed("turtles", "turtle", this, turtlesOwns, [], undefined, "default"),
+        LINKS:   new Breed("links",   "link",   this, linksOwns,   [],   false,     "default")
       }
 
       @_breeds = foldl(
         (acc, breedObj) =>
           trueVarNames    = breedObj.varNames ? []
-          defaultNames    = if breedObj.isDirected? then linksOwns.concat(linkBuiltins) else turtlesOwns.concat(turtleBuiltins)
+          defaultNames    = if breedObj.isDirected? then linksOwns else turtlesOwns
           breed           = new Breed(breedObj.name, breedObj.singular, this, trueVarNames, defaultNames, breedObj.isDirected)
           acc[breed.name] = breed
           acc

--- a/engine/src/main/coffee/engine/core/breedmanager.coffee
+++ b/engine/src/main/coffee/engine/core/breedmanager.coffee
@@ -19,7 +19,8 @@ class Breed
     @singular = @originalSingular.toLowerCase()
     @ordinal  = getNextOrdinal()
     @customVarNames = @varNames.concat(@defaultVarNames)
-    @allVarNames = @varNames.concat(@defaultVarNames).concat(@_isDirectedLinkBreed? ? linkBuiltins : turtleBuiltins)
+    @allVarNames = @varNames.concat(@defaultVarNames)
+      .concat(if typeof(@_isDirectedLinkBreed) is "undefined" then turtleBuiltins else linkBuiltins)
 
   # We can't just set this in the constructor, because people can swoop into the manager and change the turtles'
   # default shape --JAB (5/27/14)

--- a/engine/src/main/coffee/engine/core/link.coffee
+++ b/engine/src/main/coffee/engine/core/link.coffee
@@ -37,9 +37,9 @@ module.exports =
       @_updateVarsByName = genUpdate(this)
 
       @_varManager = @_genVarManager()
-      # I am hoping that this would reduce layers of calls. --John Chen May 2023
-      @getVariable  = @_varManager.getVariable
-      @setVariable  = @_varManager.setVariable
+      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      @getVariable  = @_varManager.getVariableWrapper()
+      @setVariable  = @_varManager.setVariableWrapper()
 
       Setters.setBreed.call(this, breed)
       @end1.linkManager.add(this)
@@ -173,11 +173,11 @@ module.exports =
 
     # () => Boolean
     hasVariable: (varName) ->
-      breed.allVarNames.includes(varName)
+      @_breed.allVarNames.includes(varName)
 
     # () => Array[String]
     varNames: ->
-      breed.allVarNames
+      @_breed.allVarNames
 
     # (StampMode) => Unit
     _drawStamp: (mode) ->

--- a/engine/src/main/coffee/engine/core/link.coffee
+++ b/engine/src/main/coffee/engine/core/link.coffee
@@ -37,7 +37,7 @@ module.exports =
       @_updateVarsByName = genUpdate(this)
 
       @_varManager = @_genVarManager()
-      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      # This is reducing calls anyway. --John Chen May 2023
       @getVariable  = @_varManager.getVariableWrapper()
       @setVariable  = @_varManager.setVariableWrapper()
 
@@ -46,6 +46,11 @@ module.exports =
       @end2.linkManager.add(this)
       @updateEndRelatedVars()
       @_updateVarsByName("directed?")
+
+    # This is the cheapest way to demonstrate reasonable error messages. It involves no extra checks! --John Chen May 2023
+    # (String) => Error
+    getPatchVariable: (name, sourceStart, sourceEnd) ->
+      PrimChecks.validator.error('get', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), @getBreedName())
 
     # () => String
     getBreedName: ->

--- a/engine/src/main/coffee/engine/core/link.coffee
+++ b/engine/src/main/coffee/engine/core/link.coffee
@@ -38,7 +38,10 @@ module.exports =
       @_updateVarsByName = genUpdate(this)
 
       varNames     = @_varNamesForBreed(breed)
-      @_varManager = @_genVarManager(varNames)
+      @_varManager = @_genVarManager()
+      # I am hoping that this would reduce layers of calls. --John Chen May 2023
+      @getVariable  = @_varManager.getVariable
+      @setVariable  = @_varManager.setVariable
 
       Setters.setBreed.call(this, breed)
       @end1.linkManager.add(this)
@@ -62,19 +65,6 @@ module.exports =
     # Unit -> String
     getName: ->
       @_name
-
-    # (String) => Any
-    getVariable: (varName) ->
-      @_varManager[varName]
-
-    # (String, Any) => Unit
-    setVariable: (varName, value) ->
-      @_varManager[varName] = value
-      return
-
-    # (String, Any) => Maybe[Any]
-    setIfValid: (varName, value) ->
-      @_varManager.setIfValid(varName, value)
 
     # () => DeathInterrupt
     die: ->
@@ -224,11 +214,10 @@ module.exports =
       @_registerDeath(@id)
       return
 
+    # We no longer build a list of varspecs and store them for each variable. This should reduce n(agent number)*m(variable number)+1 object allocations/stores. --John Chen May 2023
     # (Array[String]) => VariableManager
-    _genVarManager: (extraVarNames) ->
-      extraSpecs = extraVarNames.map((name) -> new ExtraVariableSpec(name))
-      allSpecs   = VariableSpecs.concat(extraSpecs)
-      new VariableManager(this, allSpecs)
+    _genVarManager: () ->
+      new VariableManager(this, VariableSpecs)
 
     # (String) => Unit
     _genVarUpdate: (varName) ->

--- a/engine/src/main/coffee/engine/core/link.coffee
+++ b/engine/src/main/coffee/engine/core/link.coffee
@@ -1,6 +1,5 @@
 # (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
 
-AbstractAgentSet = require('./abstractagentset')
 ColorModel       = require('./colormodel')
 linkCompare      = require('./structure/linkcompare')
 VariableManager  = require('./structure/variablemanager')
@@ -37,7 +36,6 @@ module.exports =
                 , @tiemode = "none") ->                                                                        # String
       @_updateVarsByName = genUpdate(this)
 
-      varNames     = @_varNamesForBreed(breed)
       @_varManager = @_genVarManager()
       # I am hoping that this would reduce layers of calls. --John Chen May 2023
       @getVariable  = @_varManager.getVariable
@@ -175,11 +173,11 @@ module.exports =
 
     # () => Boolean
     hasVariable: (varName) ->
-      @_varManager.has(varName)
+      breed.allVarNames.includes(varName)
 
     # () => Array[String]
     varNames: ->
-      @_varManager.names()
+      breed.allVarNames
 
     # (StampMode) => Unit
     _drawStamp: (mode) ->
@@ -200,14 +198,6 @@ module.exports =
     _refreshName: ->
       @_name = "#{@_breed.singular} #{@end1.id} #{@end2.id}"
       return
-
-    # (Breed) => Array[String]
-    _varNamesForBreed: (breed) ->
-      linksBreed = @world.breedManager.links()
-      if breed is linksBreed or not breed?
-        linksBreed.varNames
-      else
-        linksBreed.varNames.concat(breed.varNames)
 
     # () => Unit
     _seppuku: ->

--- a/engine/src/main/coffee/engine/core/link/linkvariables.coffee
+++ b/engine/src/main/coffee/engine/core/link/linkvariables.coffee
@@ -50,10 +50,6 @@ setBreed = (breed) ->
     trueBreed.add(this)
     @_breed?.remove(this)
 
-    newNames = @_varNamesForBreed(trueBreed)
-    oldNames = @_varNamesForBreed(@_breed)
-    @_varManager.refineBy(oldNames, newNames)
-
   @_breed = trueBreed
   @_genVarUpdate("breed")
 

--- a/engine/src/main/coffee/engine/core/observer.coffee
+++ b/engine/src/main/coffee/engine/core/observer.coffee
@@ -79,12 +79,21 @@ module.exports.Observer = class Observer
       @resetPerspective()
 
       @_varManager      = new VariableManager(this, [])
-      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      # This is reducing calls anyway. --John Chen May 2023
       @getVariable  = @_varManager.getVariableWrapper()
       @setVariable  = @_varManager.setVariableWrapper()
       @getGlobal  = @getVariable
       @setGlobal  = @setVariable
       @_codeGlobalNames = difference(@_globalNames)(@_interfaceGlobalNames)
+
+    # () => String
+    getBreedName: ->
+      "observer"
+    
+    # This is the cheapest way to demonstrate reasonable error messages. It involves no extra checks! --John Chen May 2023
+    # (String) => Error
+    getPatchVariable: (name, sourceStart, sourceEnd) ->
+      PrimChecks.validator.error('get', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), @getBreedName())
 
     # () => Unit
     clearCodeGlobals: ->

--- a/engine/src/main/coffee/engine/core/observer.coffee
+++ b/engine/src/main/coffee/engine/core/observer.coffee
@@ -79,11 +79,11 @@ module.exports.Observer = class Observer
       @resetPerspective()
 
       @_varManager      = new VariableManager(this, [])
-      # I am hoping that this would reduce layers of calls. --John Chen May 2023
-      @getGlobal  = @_varManager.getVariable
-      @getVariable  = @_varManager.getVariable
-      @setGlobal  = @_varManager.setVariable
-      @setVariable  = @_varManager.setVariable
+      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      @getVariable  = @_varManager.getVariableWrapper()
+      @setVariable  = @_varManager.setVariableWrapper()
+      @getGlobal  = @getVariable
+      @setGlobal  = @setVariable
       @_codeGlobalNames = difference(@_globalNames)(@_interfaceGlobalNames)
 
     # () => Unit

--- a/engine/src/main/coffee/engine/core/observer.coffee
+++ b/engine/src/main/coffee/engine/core/observer.coffee
@@ -78,13 +78,17 @@ module.exports.Observer = class Observer
 
       @resetPerspective()
 
-      globalSpecs       = @_globalNames.map((name) -> new ExtraVariableSpec(name))
-      @_varManager      = new VariableManager(this, globalSpecs)
+      @_varManager      = new VariableManager(this, [])
+      # I am hoping that this would reduce layers of calls. --John Chen May 2023
+      @getGlobal  = @_varManager.getVariable
+      @getVariable  = @_varManager.getVariable
+      @setGlobal  = @_varManager.setVariable
+      @setVariable  = @_varManager.setVariable
       @_codeGlobalNames = difference(@_globalNames)(@_interfaceGlobalNames)
 
     # () => Unit
     clearCodeGlobals: ->
-      forEach((name) => @_varManager[name] = 0; return)(@_codeGlobalNames)
+      forEach((name) => @_varManager.setVariable(name, 0); return)(@_codeGlobalNames)
       return
 
     # (Turtle) => Unit
@@ -93,14 +97,6 @@ module.exports.Observer = class Observer
       @_targetAgent = turtle
       @_updatePerspective()
       return
-
-    # (String) => Any
-    getGlobal: (varName) ->
-      @_varManager[varName]
-
-    # (String) => Any
-    getVariable: (varName) ->
-      @getGlobal(varName)
 
     # () => Perspective
     getPerspective: ->
@@ -127,16 +123,6 @@ module.exports.Observer = class Observer
       @_updatePerspective()
       return
 
-    # (String, Any) => Unit
-    setGlobal: (varName, value) ->
-      @_varManager[varName] = value
-      return
-
-    # (String, Any) => Unit
-    setVariable: (varName, value) ->
-      @setGlobal(varName, value)
-      return
-
     # () => Agent
     subject: ->
       @_targetAgent ? Nobody
@@ -149,7 +135,7 @@ module.exports.Observer = class Observer
 
     # () => Array[String]
     varNames: ->
-      @_varManager.names()
+      @_globalNames
 
     # (Agent) => Unit
     watch: (agent) ->

--- a/engine/src/main/coffee/engine/core/patch.coffee
+++ b/engine/src/main/coffee/engine/core/patch.coffee
@@ -33,6 +33,10 @@ module.exports =
     getName: ->
       "patch #{@pxcor} #{@pycor}"
 
+    # (String, Any) => Maybe[Any]
+    setPatchVariableIfValid: (varName, value) ->
+      @_varManager.setIfValid(varName, value)
+
     # (Turtle) => Unit
     untrackTurtle: (turtle) ->
       @_turtles.splice(@_turtles.indexOf(turtle, 0), 1)

--- a/engine/src/main/coffee/engine/core/patch.coffee
+++ b/engine/src/main/coffee/engine/core/patch.coffee
@@ -24,11 +24,11 @@ module.exports =
       @_turtles          = []
       @_varManager       = @_genVarManager()
 
-      # I am hoping that this would reduce layers of calls. --John Chen May 2023
-      @getPatchVariable  = @_varManager.getVariable
-      @getVariable  = @_varManager.getVariable
-      @setPatchVariable  = @_varManager.setVariable
-      @setVariable  = @_varManager.setVariable
+      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      @getVariable  = @_varManager.getVariableWrapper()
+      @setVariable  = @_varManager.setVariableWrapper()
+      @getPatchVariable  = @getVariable
+      @setPatchVariable  = @setVariable
 
     getName: ->
       "patch #{@pxcor} #{@pycor}"

--- a/engine/src/main/coffee/engine/core/patch.coffee
+++ b/engine/src/main/coffee/engine/core/patch.coffee
@@ -24,14 +24,19 @@ module.exports =
       @_turtles          = []
       @_varManager       = @_genVarManager()
 
-      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      # This is reducing calls anyway. --John Chen May 2023
       @getVariable  = @_varManager.getVariableWrapper()
       @setVariable  = @_varManager.setVariableWrapper()
       @getPatchVariable  = @getVariable
       @setPatchVariable  = @setVariable
 
+    # () => String
     getName: ->
       "patch #{@pxcor} #{@pycor}"
+
+    # () => String
+    getBreedName: ->
+      "patches"
 
     # (String, Any) => Maybe[Any]
     setPatchVariableIfValid: (varName, value) ->

--- a/engine/src/main/coffee/engine/core/patch.coffee
+++ b/engine/src/main/coffee/engine/core/patch.coffee
@@ -24,30 +24,14 @@ module.exports =
       @_turtles          = []
       @_varManager       = @_genVarManager(@world.patchesOwnNames)
 
+      # I am hoping that this would reduce layers of calls. --John Chen May 2023
+      @getPatchVariable  = @_varManager.getVariable
+      @getVariable  = @_varManager.getVariable
+      @setPatchVariable  = @_varManager.setVariable
+      @setVariable  = @_varManager.setVariable
+
     getName: ->
       "patch #{@pxcor} #{@pycor}"
-
-    # (String) => Any
-    getVariable: (varName) ->
-      @_varManager[varName]
-
-    # (String, Any) => Unit
-    setVariable: (varName, value) ->
-      @_varManager[varName] = value
-      return
-
-    # (String) => Any
-    getPatchVariable: (varName) ->
-      @_varManager[varName]
-
-    # (String, Any) => Unit
-    setPatchVariable: (varName, value) ->
-      @_varManager[varName] = value
-      return
-
-    # (String, Any) => Maybe[Any]
-    setPatchVariableIfValid: (varName, value) ->
-      @_varManager.setIfValid(varName, value)
 
     # (Turtle) => Unit
     untrackTurtle: (turtle) ->
@@ -158,7 +142,7 @@ module.exports =
 
     # () => Unit
     reset: ->
-      @_varManager.reset(@world.patchesOwnNames)
+      @_varManager.reset()
       Setters.setPcolor.call(this, 0)
       Setters.setPlabel.call(this, '')
       Setters.setPlabelColor.call(this, 9.9)
@@ -172,11 +156,10 @@ module.exports =
     varNames: ->
       @_varManager.names()
 
+    # We no longer build a list of varspecs and store them for each variable. This should reduce n(agent number)*m(variable number)+1 object allocations/stores. --John Chen May 2023
     # Array[String] => VariableManager
-    _genVarManager: (extraVarNames) ->
-      extraSpecs = extraVarNames.map((name) -> new ExtraVariableSpec(name))
-      allSpecs   = VariableSpecs.concat(extraSpecs)
-      new VariableManager(this, allSpecs)
+    _genVarManager: () ->
+      new VariableManager(this, VariableSpecs)
 
     # (String) => Unit
     _genVarUpdate: (varName) ->

--- a/engine/src/main/coffee/engine/core/patch.coffee
+++ b/engine/src/main/coffee/engine/core/patch.coffee
@@ -22,7 +22,7 @@ module.exports =
     constructor: (@id, @pxcor, @pycor, @world, @_genUpdate, @_declareNonBlackPatch, @_decrementPatchLabelCount
                 , @_incrementPatchLabelCount, @_pcolor = 0.0, @_plabel = "", @_plabelcolor = 9.9) ->
       @_turtles          = []
-      @_varManager       = @_genVarManager(@world.patchesOwnNames)
+      @_varManager       = @_genVarManager()
 
       # I am hoping that this would reduce layers of calls. --John Chen May 2023
       @getPatchVariable  = @_varManager.getVariable
@@ -150,11 +150,11 @@ module.exports =
 
     # () => Boolean
     hasVariable: (varName) ->
-      @_varManager.has(varName)
+      @world.patchesVariables.includes(varName)
 
     # () => Array[String]
     varNames: ->
-      @_varManager.names()
+      @world.patchesVariables
 
     # We no longer build a list of varspecs and store them for each variable. This should reduce n(agent number)*m(variable number)+1 object allocations/stores. --John Chen May 2023
     # Array[String] => VariableManager

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -53,8 +53,9 @@ module.exports =
 
     # () => Unit
     reset: () ->
-      for varName of Object.keys(@_values)
-        delete @_values[varName] if not @_setters.hasOwnProperty(varName)
+      # Why did Coffeescript chose a different behavior of for..of and for..in than Javascript? This is very confusing. -- John Chen May 2023
+      for varName in Object.keys(@_values)
+        delete @_values[varName]
       return
 
     # ExtraVariableSpec is no longer a thing. We only care about built-in variables as special cases. --John Chen May 2023

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -30,7 +30,7 @@ module.exports =
         @[varName]
       else
         value = @_values.get(varName)
-        if typeof MyVariable isnt "undefined"
+        if typeof value isnt "undefined"
           value
         else
           @_values.set(varName, 0)

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -21,8 +21,8 @@ module.exports =
     # We validate the variable names in prim checks, and had no checks for globals anyway. So why bother? --John Chen May 2023
     # (Agent, Array[VariableSpec[_]]) => VariableManager
     constructor: (@agent, varSpecs) ->
-      @_values          = new Object(null);
-      @_setters         = new Object(null);
+      @_values          = new Object(null)
+      @_setters         = new Object(null)
       @_addVarsBySpec(varSpecs)
 
     # (String) => Any

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -27,23 +27,31 @@ module.exports =
       if @hasOwnProperty(varName)
         @_varManager[varName]
       else
-        value = _values.get(varName)
+        value = @_values.get(varName)
         if typeof MyVariable isnt "undefined"
           value
         else
-          _values.set(varName, 0)
+          @_values.set(varName, 0)
           0
+    
+    # () => (String) => Any
+    getVariableWrapper: () ->
+      (varName) => @getVariable(varName)
 
     # (String, Any) => Unit
     setVariable: (varName, value) ->
       if @hasOwnProperty(varName)
         @_varManager[varName] = value
-      else _values.set(varName, value)
+      else @_values.set(varName, value)
       return
+
+    # () => (String) => Any
+    setVariableWrapper: () ->
+      (varName, value) => @setVariable(varName, value)
 
     # (Array[VariableSpec]) => Unit
     reset: () ->
-      _values.clear()
+      @_values.clear()
       return
 
     # ExtraVariableSpec is no longer a thing. We only care about built-in variables as special cases. --John Chen May 2023

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -53,6 +53,8 @@ module.exports =
 
     # () => Unit
     reset: () ->
+      for varName of Object.keys(@_values)
+        delete @_values[varName] if not _setters.has(varName)
       return
 
     # ExtraVariableSpec is no longer a thing. We only care about built-in variables as special cases. --John Chen May 2023

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -54,7 +54,7 @@ module.exports =
     # () => Unit
     reset: () ->
       for varName of Object.keys(@_values)
-        delete @_values[varName] if not @_setters.has(varName)
+        delete @_values[varName] if not @_setters.hasOwnProperty(varName)
       return
 
     # ExtraVariableSpec is no longer a thing. We only care about built-in variables as special cases. --John Chen May 2023

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -54,7 +54,6 @@ module.exports =
           if spec instanceof MutableVariableSpec
             get = do (spec) -> (-> spec.get.call(@agent))
             set = do (spec) -> ((v) -> spec.set.call(@agent, v))
-            @_validitySetters.set(spec.name, spec.set)
             { configurable: true, get, set }
           else if spec instanceof ImmutableVariableSpec
             { value: spec.get.call(@agent), writable: false }

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -7,8 +7,8 @@
 { exceptionFactory: exceptions } = require('util/exception')
 
 module.exports =
-  # I re-implemented the variable manager as two tiers: Map for custom variables; and Object.defineProperty for built-in variables. 
-  # This allows for higher performance, less memory consumption, both in terms of creation of VarManagers, and in terms of memory consumption. 
+  # I re-implemented the variable manager as two tiers: Map for custom variables; and Object.defineProperty for built-in variables.
+  # This allows for higher performance, less memory consumption, both in terms of creation of VarManagers, and in terms of memory consumption.
   # The final straw: if you define a turtle variable calls "has", it breaks the entire system!
   # A related article: https://www.zhenghao.io/posts/object-vs-map --John Chen May 2023
   class VariableManager
@@ -26,7 +26,7 @@ module.exports =
 
     # (String) => Any
     getVariable: (varName) ->
-      if @hasOwnProperty(varName)
+      if @_validitySetters.has(varName)
         @[varName]
       else
         value = @_values.get(varName)
@@ -42,7 +42,7 @@ module.exports =
 
     # (String, Any) => Unit
     setVariable: (varName, value) ->
-      if @hasOwnProperty(varName)
+      if @_validitySetters.has(varName)
         @[varName] = value
       else @_values.set(varName, value)
       return

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -26,7 +26,7 @@ module.exports =
 
     # (String) => Any
     getVariable: (varName) ->
-      if @_validitySetters.has(varName)
+      if @hasOwnProperty(varName)
         @[varName]
       else
         value = @_values.get(varName)
@@ -42,7 +42,7 @@ module.exports =
 
     # (String, Any) => Unit
     setVariable: (varName, value) ->
-      if @_validitySetters.has(varName)
+      if @hasOwnProperty(varName)
         @[varName] = value
       else @_values.set(varName, value)
       return

--- a/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
+++ b/engine/src/main/coffee/engine/core/structure/variablemanager.coffee
@@ -54,7 +54,7 @@ module.exports =
     # () => Unit
     reset: () ->
       for varName of Object.keys(@_values)
-        delete @_values[varName] if not _setters.has(varName)
+        delete @_values[varName] if not @_setters.has(varName)
       return
 
     # ExtraVariableSpec is no longer a thing. We only care about built-in variables as special cases. --John Chen May 2023

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -305,6 +305,10 @@ module.exports =
       @getPatchHere().setVariable(varName, value)
       return
 
+    # (String, Any) => Maybe[Any]
+    setPatchVariableIfValid: (varName, value) ->
+      @getPatchHere().setIfValid(varName, value)
+
     # () => PatchSet
     getNeighbors: ->
       @getPatchHere().getNeighbors()

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -53,9 +53,9 @@ module.exports =
       @linkManager = new TurtleLinkManager(@id, @world)
 
       @_varManager = @_genVarManager()
-      # I am hoping that this would reduce layers of calls. --John Chen May 2023
-      @getVariable  = @_varManager.getVariable
-      @setVariable  = @_varManager.setVariable
+      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      @getVariable  = @_varManager.getVariableWrapper()
+      @setVariable  = @_varManager.setVariableWrapper()
 
       Setters.setBreed.call(this, breed)
 
@@ -386,11 +386,11 @@ module.exports =
 
     # () => Boolean
     hasVariable: (varName) ->
-      breed.allVarNames.includes(varName)
+      @_breed.allVarNames.includes(varName)
 
     # () => Array[String]
     varNames: ->
-      breed.allVarNames
+      @_breed.allVarNames
 
     # (StampMode) => Unit
     _drawStamp: (mode) ->

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -334,10 +334,9 @@ module.exports =
       shape    = if breed is @_breed then @_givenShape else undefined
       turtle   = @_createTurtle(@_color, @_heading, @xcor, @ycor, breed, @_label, @_labelcolor, @_hidden, @_size, shape, (self) => @penManager.clone(@_genUpdate(self)))
       forEach((varName) =>
-        if varName isnt "who"
-          turtle.setVariable(varName, @getVariable(varName) ? 0)
+        turtle.setVariable(varName, @getVariable(varName) ? 0)
         return
-      )(breed.allVarNames)
+      )(breed.customVarNames)
       turtle
 
     # (Turtle|Patch) => Unit

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -53,7 +53,7 @@ module.exports =
       @linkManager = new TurtleLinkManager(@id, @world)
 
       @_varManager = @_genVarManager()
-      # No, this is not reducing calls. I am too lazy to revert this change now. --John Chen May 2023
+      # This is reducing calls anyway. --John Chen May 2023
       @getVariable  = @_varManager.getVariableWrapper()
       @setVariable  = @_varManager.setVariableWrapper()
 

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -1,6 +1,5 @@
 # (C) Uri Wilensky. https://github.com/NetLogo/Tortoise
 
-AbstractAgentSet  = require('./abstractagentset')
 ColorModel        = require('engine/core/colormodel')
 TurtleLinkManager = require('./turtlelinkmanager')
 TurtleSet         = require('./turtleset')
@@ -53,7 +52,6 @@ module.exports =
       @penManager  = genPenManager(this)
       @linkManager = new TurtleLinkManager(@id, @world)
 
-      varNames     = @_varNamesForBreed(breed)
       @_varManager = @_genVarManager()
       # I am hoping that this would reduce layers of calls. --John Chen May 2023
       @getVariable  = @_varManager.getVariable
@@ -335,20 +333,11 @@ module.exports =
     _makeTurtleCopy: (breed) ->
       shape    = if breed is @_breed then @_givenShape else undefined
       turtle   = @_createTurtle(@_color, @_heading, @xcor, @ycor, breed, @_label, @_labelcolor, @_hidden, @_size, shape, (self) => @penManager.clone(@_genUpdate(self)))
-      varNames = @_varNamesForBreed(breed)
       forEach((varName) =>
         turtle.setVariable(varName, @getVariable(varName) ? 0)
         return
-      )(varNames)
+      )(breed.allVarNames)
       turtle
-
-    # (Breed) => Array[String]
-    _varNamesForBreed: (breed) ->
-      turtlesBreed = @world.breedManager.turtles()
-      if breed is turtlesBreed or not breed?
-        turtlesBreed.varNames
-      else
-        turtlesBreed.varNames.concat(breed.varNames)
 
     # (Turtle|Patch) => Unit
     moveTo: (agent) ->
@@ -397,11 +386,11 @@ module.exports =
 
     # () => Boolean
     hasVariable: (varName) ->
-      @_varManager.has(varName)
+      breed.allVarNames.includes(varName)
 
     # () => Array[String]
     varNames: ->
-      @_varManager.names()
+      breed.allVarNames
 
     # (StampMode) => Unit
     _drawStamp: (mode) ->

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -334,7 +334,8 @@ module.exports =
       shape    = if breed is @_breed then @_givenShape else undefined
       turtle   = @_createTurtle(@_color, @_heading, @xcor, @ycor, breed, @_label, @_labelcolor, @_hidden, @_size, shape, (self) => @penManager.clone(@_genUpdate(self)))
       forEach((varName) =>
-        turtle.setVariable(varName, @getVariable(varName) ? 0)
+        if varName isnt "who"
+          turtle.setVariable(varName, @getVariable(varName) ? 0)
         return
       )(breed.allVarNames)
       turtle

--- a/engine/src/main/coffee/engine/core/turtle.coffee
+++ b/engine/src/main/coffee/engine/core/turtle.coffee
@@ -307,7 +307,7 @@ module.exports =
 
     # (String, Any) => Maybe[Any]
     setPatchVariableIfValid: (varName, value) ->
-      @getPatchHere().setIfValid(varName, value)
+      @getPatchHere().setPatchVariableIfValid(varName, value)
 
     # () => PatchSet
     getNeighbors: ->

--- a/engine/src/main/coffee/engine/core/turtle/turtlevariables.coffee
+++ b/engine/src/main/coffee/engine/core/turtle/turtlevariables.coffee
@@ -109,10 +109,6 @@ setBreed = (breed) ->
     trueBreed.add(this)
     @_breed?.remove(this)
 
-    newNames = @_varNamesForBreed(trueBreed)
-    oldNames = @_varNamesForBreed(@_breed)
-    @_varManager.refineBy(oldNames, newNames)
-
   @_breed = trueBreed
   @_genVarUpdate("breed")
 

--- a/engine/src/main/coffee/engine/core/world.coffee
+++ b/engine/src/main/coffee/engine/core/world.coffee
@@ -46,6 +46,7 @@ module.exports =
     # Optimization-related variables
     _patchesAllBlack:   undefined # Boolean
     _patchesWithLabels: undefined # Number
+    patchesVariables:   undefined # Array[String]
 
     constructor: (
       miniWorkspace        # MiniWorkspace
@@ -80,6 +81,7 @@ module.exports =
 
       @_patchesAllBlack   = true
       @_patchesWithLabels = 0
+      @patchesVariables = @patchesOwnNames.concat(patchBuiltins)
 
       @_updater.collectUpdates()
       @_updater.registerWorldState({

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -4,6 +4,8 @@
 
 { TowardsInterrupt } = require('util/interrupts')
 
+{ checks } = require('engine/core/typechecker')
+
 # (() => Agent, Validator) => (String, Map[Any, String]) => (Any) => Unit
 genSetter = (getSelf, validator) -> (name, mappings) ->
   (value) =>
@@ -53,12 +55,14 @@ class LinkChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     link = @getSelf()
     if @_setterChecks.has(name)
-      check = @_setterChecks.get(name)
-      check(value)
+      if !checks.isLink(link)
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), link.getBreedName())
+      else
+        check = @_setterChecks.get(name)
+        check(value)
     else if not link.hasVariable(name)
       msgKey    = "_ breed does not own variable _"
-      upperName = name.toUpperCase()
-      @validator.error('set', sourceStart, sourceEnd, msgKey, link.getBreedName(), upperName)
+      @validator.error('set', sourceStart, sourceEnd, msgKey, link.getBreedName(), name.toUpperCase())
     else
       link._varManager.setVariable(name, value)
 

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -56,7 +56,8 @@ class LinkChecks
     link = @getSelf()
     if @_setterChecks.has(name)
       if !checks.isLink(link)
-        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), link.getBreedName())
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
+          if link is 0 then "OBSERVER" else link.getBreedName())
       else
         check = @_setterChecks.get(name)
         check(value)

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -52,13 +52,13 @@ class LinkChecks
   # (Int, Int, String, Any) => Unit
   setVariable: (sourceStart, sourceEnd, name, value) ->
     link = @getSelf()
-    if not link.hasVariable(name)
+    if @_setterChecks.has(name)
+      check = @_setterChecks.get(name)
+      check(value)
+    else if not link.hasVariable(name)
       msgKey    = "_ breed does not own variable _"
       upperName = name.toUpperCase()
       @validator.error('set', sourceStart, sourceEnd, msgKey, link.getBreedName(), upperName)
-    else if @_setterChecks.has(name)
-      check = @_setterChecks.get(name)
-      check(value)
     else
       link._varManager.setVariable(name, value)
 

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -60,7 +60,7 @@ class LinkChecks
       check = @_setterChecks.get(name)
       check(value)
     else
-      link.setVariable(name, value)
+      link._varManager.setVariable(name, value)
 
     return
 
@@ -72,6 +72,6 @@ class LinkChecks
       upperName = name.toUpperCase()
       @validator.error(upperName, sourceStart, sourceEnd, msgKey, link.getBreedName(), upperName)
     else
-      link.getVariable(name)
+      link._varManager.getVariable(name)
 
 module.exports = LinkChecks

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -14,7 +14,7 @@ genSetter = (getSelf, validator) -> (name, mappings) ->
         defaultMsg = "An unknown error occurred when setting the '#{name}' of \
 '#{link}': #{error}"
         validator.error('set', null, null, msg ? defaultMsg)
-    )(link.setIfValid(name, value))
+    )(link.setVariable(name, value))
     return
 
 class LinkChecks

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -55,7 +55,7 @@ class LinkChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     link = @getSelf()
     if @_setterChecks.has(name)
-      if !checks.isLink(link)
+      if not checks.isLink(link)
         @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
           if link is 0 then "OBSERVER" else link.getBreedName())
       else

--- a/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/link-checks.coffee
@@ -14,7 +14,7 @@ genSetter = (getSelf, validator) -> (name, mappings) ->
         defaultMsg = "An unknown error occurred when setting the '#{name}' of \
 '#{link}': #{error}"
         validator.error('set', null, null, msg ? defaultMsg)
-    )(link.setVariable(name, value))
+    )(link._varManager.setIfValid(name, value))
     return
 
 class LinkChecks

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -62,8 +62,11 @@ class PatchChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     patchOrTurtle = @getSelf()
     if @_setterChecks.has(name)
-      check = @_setterChecks.get(name)
-      check(value)
+      if !checks.isPatch(patchOrTurtle) && !checks.isTurtle(patchOrTurtle)
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), patchOrTurtle.getBreedName())
+      else
+        check = @_setterChecks.get(name)
+        check(value)
     else
       patchOrTurtle.setPatchVariable(name, value)
 
@@ -71,6 +74,6 @@ class PatchChecks
 
   # (Int, Int, String) => Any
   getVariable: (sourceStart, sourceEnd, name) ->
-    @getSelf().getPatchVariable(name)
+    @getSelf().getPatchVariable(name, sourceStart, sourceEnd)
 
 module.exports = PatchChecks

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -63,7 +63,8 @@ class PatchChecks
     patchOrTurtle = @getSelf()
     if @_setterChecks.has(name)
       if !checks.isPatch(patchOrTurtle) && !checks.isTurtle(patchOrTurtle)
-        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), patchOrTurtle.getBreedName())
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
+          if patchOrTurtle is 0 then "OBSERVER" else patchOrTurtle.getBreedName())
       else
         check = @_setterChecks.get(name)
         check(value)

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -20,7 +20,7 @@ genSetter = (getSelf, validator) -> (name, mappings) -> (value) ->
 
       validator.error('set', null, null, msg ? defaultMsg, environment)
 
-  )(pot._varManager.setIfValid(name, value))
+  )(pot.setPatchVariableIfValid(name, value))
 
   return
 

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -20,7 +20,7 @@ genSetter = (getSelf, validator) -> (name, mappings) -> (value) ->
 
       validator.error('set', null, null, msg ? defaultMsg, environment)
 
-  )(pot.setPatchVariableIfValid(name, value))
+  )(pot.setPatchVariable(name, value))
 
   return
 

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -20,7 +20,7 @@ genSetter = (getSelf, validator) -> (name, mappings) -> (value) ->
 
       validator.error('set', null, null, msg ? defaultMsg, environment)
 
-  )(pot.setPatchVariable(name, value))
+  )(pot._varManager.setIfValid(name, value))
 
   return
 

--- a/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/patch-checks.coffee
@@ -62,7 +62,7 @@ class PatchChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     patchOrTurtle = @getSelf()
     if @_setterChecks.has(name)
-      if !checks.isPatch(patchOrTurtle) && !checks.isTurtle(patchOrTurtle)
+      if not checks.isPatch(patchOrTurtle) and not checks.isTurtle(patchOrTurtle)
         @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
           if patchOrTurtle is 0 then "OBSERVER" else patchOrTurtle.getBreedName())
       else

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -14,7 +14,7 @@ genSetter = (getSelf, validator) -> (name, mappings) ->
         defaultMsg = "An unknown error occurred when setting the '#{name}' of \
 '#{turtle}': #{error}"
         validator.error('set', null, null, msg ? defaultMsg)
-    )(turtle.setVariable(name, value))
+    )(turtle._varManager.setIfValid(name, value))
     return
 
 class TurtleChecks

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -71,7 +71,7 @@ class TurtleChecks
       upperName = name.toUpperCase()
       @validator.error(upperName, sourceStart, sourceEnd, msgKey, turtle.getBreedName(), upperName)
     else
-      turtle.getVariable(name)
+      turtle._varManager.getVariable(name)
 
   # (Int, Int, String, Any) => Unit
   setVariable: (sourceStart, sourceEnd, name, value) ->
@@ -84,7 +84,7 @@ class TurtleChecks
       check = @_setterChecks.get(name)
       check(value)
     else
-      turtle.setVariable(name, value)
+      turtle._varManager.setVariable(name, value)
 
     return
 

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -79,7 +79,7 @@ class TurtleChecks
     if @_setterChecks.has(name)
       check = @_setterChecks.get(name)
       check(value)
-    if not turtle.hasVariable(name)
+    else if not turtle.hasVariable(name)
       msgKey    = "_ breed does not own variable _"
       upperName = name.toUpperCase()
       @validator.error('set', sourceStart, sourceEnd, msgKey, turtle.getBreedName(), upperName)

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -14,18 +14,17 @@ genSetter = (getSelf, validator) -> (name, mappings) ->
         defaultMsg = "An unknown error occurred when setting the '#{name}' of \
 '#{turtle}': #{error}"
         validator.error('set', null, null, msg ? defaultMsg)
-    )(turtle.setIfValid(name, value))
+    )(turtle.setVariable(name, value))
     return
 
 class TurtleChecks
 
-  _getterChecks: null # Map[String, (Any) => Unit]
   _setterChecks: null # Map[String, (Any) => Unit]
 
   # (Validator, () => Agent, TurtleManager, BreedManager)
   constructor: (@validator, @getSelf, @turtleManager, @breedManager) ->
 
-    @_getterChecks = new Map()
+    # Removed the getter check since it is never used and I cannot imagine the scenario of using it - John Chen May 2023
 
     cannotMoveMsg       = "Cannot move turtle beyond the world_s edge."
     invalidRGBMsg       = "An rgb list must contain 3 or 4 numbers 0-255"
@@ -71,9 +70,6 @@ class TurtleChecks
       msgKey    = "_ breed does not own variable _"
       upperName = name.toUpperCase()
       @validator.error(upperName, sourceStart, sourceEnd, msgKey, turtle.getBreedName(), upperName)
-    else if @_getterChecks.has(name)
-      check = @_getterChecks.get(name)
-      check(name)
     else
       turtle.getVariable(name)
 

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -80,7 +80,8 @@ class TurtleChecks
     turtle = @getSelf()
     if @_setterChecks.has(name)
       if !checks.isTurtle(turtle)
-        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), turtle.getBreedName())
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
+          if turtle is 0 then "OBSERVER" else turtle.getBreedName())
       else
         check = @_setterChecks.get(name)
         check(value)

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -4,6 +4,8 @@
 
 { TopologyInterrupt, TowardsInterrupt } = require('util/interrupts')
 
+{ checks } = require('engine/core/typechecker')
+
 # (() => Agent, Validator) => (String, Map[Any, String]) => (Any) => Unit
 genSetter = (getSelf, validator) -> (name, mappings) ->
   (value) =>
@@ -77,12 +79,14 @@ class TurtleChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     turtle = @getSelf()
     if @_setterChecks.has(name)
-      check = @_setterChecks.get(name)
-      check(value)
+      if !checks.isTurtle(turtle)
+        @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(), turtle.getBreedName())
+      else
+        check = @_setterChecks.get(name)
+        check(value)
     else if not turtle.hasVariable(name)
       msgKey    = "_ breed does not own variable _"
-      upperName = name.toUpperCase()
-      @validator.error('set', sourceStart, sourceEnd, msgKey, turtle.getBreedName(), upperName)
+      @validator.error('set', sourceStart, sourceEnd, msgKey, turtle.getBreedName(), name.toUpperCase())
     else
       turtle._varManager.setVariable(name, value)
 

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -79,7 +79,7 @@ class TurtleChecks
   setVariable: (sourceStart, sourceEnd, name, value) ->
     turtle = @getSelf()
     if @_setterChecks.has(name)
-      if !checks.isTurtle(turtle)
+      if not checks.isTurtle(turtle)
         @validator.error('set', sourceStart, sourceEnd, '_ does not exist in _.', name.toUpperCase(),
           if turtle is 0 then "OBSERVER" else turtle.getBreedName())
       else

--- a/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
+++ b/engine/src/main/coffee/engine/prim-checks/turtle-checks.coffee
@@ -76,13 +76,13 @@ class TurtleChecks
   # (Int, Int, String, Any) => Unit
   setVariable: (sourceStart, sourceEnd, name, value) ->
     turtle = @getSelf()
+    if @_setterChecks.has(name)
+      check = @_setterChecks.get(name)
+      check(value)
     if not turtle.hasVariable(name)
       msgKey    = "_ breed does not own variable _"
       upperName = name.toUpperCase()
       @validator.error('set', sourceStart, sourceEnd, msgKey, turtle.getBreedName(), upperName)
-    else if @_setterChecks.has(name)
-      check = @_setterChecks.get(name)
-      check(value)
     else
       turtle._varManager.setVariable(name, value)
 

--- a/engine/src/main/coffee/i18n/en_us.coffee
+++ b/engine/src/main/coffee/i18n/en_us.coffee
@@ -32,6 +32,11 @@ bundle = {
   , 'Color must be a number or a valid RGB/A color list with 3 - 4 numbers that have values between 0 and 255.': () ->
       'Color must be a number or a valid RGB/A color list with 3 - 4 numbers that have values between 0 and 255.'
 
+  # Type Check
+
+  , '_ does not exist in _.': (v, b) ->
+      "Variable #{v} does not exist in breed #{b}."
+
   # Other Prims
 
   , 'random-normal_s second input can_t be negative.': () ->

--- a/engine/src/main/coffee/i18n/i18n-bundle.coffee
+++ b/engine/src/main/coffee/i18n/i18n-bundle.coffee
@@ -45,8 +45,8 @@ class I18nBundle
       @_current = BUNDLES[locale]
 
     else
-      if not @_warnings.has(locale)
-        @_warning.add(locale)
+      if not _warnings.has(locale)
+        _warning.add(locale)
         console.warn("Unsupported locale '#{locale}', reverting to 'en_us'.")
 
       @_current = EN_US

--- a/engine/src/main/coffee/i18n/zh_cn.coffee
+++ b/engine/src/main/coffee/i18n/zh_cn.coffee
@@ -27,6 +27,11 @@ bundle = {
   , 'Can_t take logarithm of _.': (n) ->
       "无法为值 #{n} 取对数。"
 
+  # Type Check
+
+  , '_ does not exist in _.': (v, b) ->
+      "#{breed} 中不存在变量 #{v}。"
+
   # Color Prims
 
   , 'Color must be a number or a valid RGB/A color list with 3 - 4 numbers that have values between 0 and 255.': () ->


### PR DESCRIPTION
Related emails:

I was thinking about how to allow a "temporary model" that goes above the current world - e.g. thinking about AI generating a snippet with breed definitions and procedures, yet we don't want that to override the model unless the user wants it. Then I realized that there are some checks there that prevent it - because although I can compile things like 

```
globals [ a-temporary-variable ]
```

There is no way to initialize it in advance. So I started to read the relevant code again, and find a real issue: user-defined variables can override the built-in methods of VarManager (!) since we are defining properties during initialization!

So, try adding `has` to any NLW model as a turtle variable, and you immediately break it. That's not good. So right now I am working on a major refactor to clear all that mess, switch to Map-based implementation, and reduce memory consumption. I am not sure if this is going to increase performance - I mean it is going to benefit agent initialization as I plan to do it lazily, but the access could be slightly more complicated.

===

The performance should be on par with before the refactoring, or slightly improve, depending on the nature of the model.

The good thing is that we eliminate a ton of unnecessary memory allocation and ease the burden of GC. We also eliminate the `has` bug. It is now easier to dynamically add turtle/breed variables - the very reason I am doing this. So, if there is a model that involves a large amount of variable reading, it is going to benefit. Otherwise, the speed should stay similar, with a lowered memory footprint for each agent. 

===

I just realized that Map is not always better than Object in terms of serving as a HashTable; especially, if the table is going to have no more than a few keys. however, if we ever want to use an Object for that purpose, we need to start from empty `new Object(null)` and use a separate object for the purpose. 

In some models I made, I saw around 10% performance gain; they both heavily use turtle, patch, or link variables, which is the main reason. 