### PR TITLE
Support narrowcast plots for HubNet Web

### DIFF
--- a/compiler/js/src/main/scala/BrowserCompiler.scala
+++ b/compiler/js/src/main/scala/BrowserCompiler.scala
@@ -12,10 +12,11 @@ import json.JsonWriter
 import json.JsonWriter.string2TortoiseJs
 import json.TortoiseJson
 import json.TortoiseJson._
+import json.WidgetToJson
 
 import org.nlogo.tortoise.macros.json.Jsonify
 
-import org.nlogo.core.CompilerException
+import org.nlogo.core.{ CompilerException, Plot }
 import org.nlogo.core.model.ModelReader
 
 import org.nlogo.parse.CompilerUtilities
@@ -42,6 +43,11 @@ class BrowserCompiler {
 
   private val compiler = new Compiler()
 
+  private val DefaultCRJS = {
+    val tjs = JsObject(fields("code" -> JsString(""), "widgets" -> JsArray(Seq())))
+    JsonLibrary.toNative(tjs)
+  }
+
   @JSExport
   def fromModel(compilationRequest: NativeJson): NativeJson = {
 
@@ -63,16 +69,19 @@ class BrowserCompiler {
   }
 
   @JSExport
-  def fromNlogo(contents: String, commandJson: NativeJson): NativeJson = {
+  def fromNlogo(contents: String, commandJson: NativeJson
+               , compilationRequest: NativeJson = DefaultCRJS): NativeJson = {
 
     val compilationResult =
       for {
         commands      <- readArray[String](commandJson, "commands")
-        compiledModel =  CompiledModel.fromNlogoContents(contents, compiler)
+        tortoiseReq   <- readNative[JsObject](compilationRequest)
+        parsedRequest <- CompilationRequest.read(tortoiseReq).leftMap(_.map(FailureString))
+        compiledModel =  CompiledModel.fromNlogoContents(contents, compiler, parsedRequest.widgets)
         compilation   <- transformErrorsAndUpdateModel(compiledModel, compileExtras(commands, Seq()))
       } yield compilation
 
-    JsonLibrary.toNative(compilationResult.toJsonObj)
+    JsonLibrary.toNative(compilationResult.leftMap(_.map(fail => fail: TortoiseFailure)).toJsonObj)
 
   }
 
@@ -101,6 +110,41 @@ class BrowserCompiler {
       , this.lastCompiledModel.compilation.procedures
       , compiler.extensionManager
     )
+
+  @JSExport
+  def compilePlots(plotJSON: NativeJson): NativeJson = {
+
+    def conv[E, T](t: ValidationNel[E, T])
+                  (f: (E) => TortoiseFailure): ValidationNel[TortoiseFailure, T] =
+      t.leftMap(_.map(f))
+
+    def convStr[T](t: ValidationNel[String, T]) =
+      conv(t)(x => FailureException(new Exception(x)))
+
+    def convComp[T](t: ValidationNel[CompilerException, T]) =
+      conv(t)(x => FailureCompilerException(x))
+
+    val results: ValidationNel[TortoiseFailure, String] =
+      for {
+        tortoiseJSON <- readNative[JsArray](plotJSON)
+        widgets      <- convStr(WidgetToJson.readWidgetsJson(tortoiseJSON))
+        plots         = widgets.collect { case p: Plot => p }
+        plotJS       <- convComp(CompiledModel.plotsToJS(plots, lastCompiledModel))
+      } yield plotJS
+
+    val json =
+      results.fold(
+        es => JsObject(fields(
+          "success" -> JsBool(false),
+          "result"  -> JsArray(es.list.toList.map((f: TortoiseFailure) => f.toJsonObj)))),
+        success => JsObject(fields(
+          "success" -> JsBool(true),
+          "result"  -> JsString(success)))
+      )
+
+    JsonLibrary.toNative(json)
+
+  }
 
   @JSExport
   def compileCommand(command: String): NativeJson = {

--- a/compiler/shared/src/main/scala/Compiler.scala
+++ b/compiler/shared/src/main/scala/Compiler.scala
@@ -90,6 +90,15 @@ class Compiler {
 
   }
 
+  def plotsToJS(widgets: Seq[CompiledWidget]): String = {
+    val globalModelConfig = JsStatement("global.modelConfig", Polyfills.content)
+    TortoiseLoader.integrateSymbols(
+         PlotCompiler.formatPlots(widgets)
+      :+ globalModelConfig
+      :+ resolveModelConfig
+    )
+  }
+
   def compileReporter(
     logo:          String,
     oldProcedures: ProceduresMap = NoProcedures,

--- a/engine/src/main/coffee/engine/plot/plot.coffee
+++ b/engine/src/main/coffee/engine/plot/plot.coffee
@@ -275,4 +275,4 @@ module.exports = class Plot
 
   # [T] @ ((Pen) => T) => T
   _withPen: (f) ->
-    fold(-> throw exceptions.runtime("Plot '#{@name}' has no pens!", "plot"))(f)(@_currentPenMaybe)
+    fold(=> throw exceptions.runtime("Plot '#{@name}' has no pens!", "plot"))(f)(@_currentPenMaybe)

--- a/engine/src/main/coffee/engine/plot/plotmanager.coffee
+++ b/engine/src/main/coffee/engine/plot/plotmanager.coffee
@@ -2,11 +2,11 @@
 
 { DisplayMode: { displayModeFromNum } } = require('./pen')
 
-{ filter, forEach, map, toObject, zip }               = require('brazierjs/array')
-{ flip, pipeline }                                    = require('brazierjs/function')
-{ flatMap: flatMapMaybe, fold, map: mapMaybe, maybe } = require('brazierjs/maybe')
-{ values }                                            = require('brazierjs/object')
-{ isNumber }                                          = require('brazierjs/type')
+{ filter, forEach, map, toObject, zip }                     = require('brazierjs/array')
+{ flip, pipeline }                                          = require('brazierjs/function')
+{ flatMap: flatMapMaybe, fold, map: mapMaybe, maybe, None } = require('brazierjs/maybe')
+{ values }                                                  = require('brazierjs/object')
+{ isNumber }                                                = require('brazierjs/type')
 
 { exceptionFactory: exceptions } = require('util/exception')
 
@@ -20,6 +20,13 @@ module.exports = class PlotManager
     toName             = (p) -> p.name.toUpperCase()
     @_currentPlotMaybe = maybe(plots[plots.length - 1])
     @_plotMap          = pipeline(map(toName), flip(zip)(plots), toObject)(plots)
+
+  # (Plot) => Unit
+  addPlot: (plot) ->
+    name = plot.name.toUpperCase()
+    if not @_plotMap[name]?
+      @_plotMap[name] = plot
+    return
 
   # () => Unit
   clearAllPlots: ->
@@ -114,6 +121,16 @@ module.exports = class PlotManager
   # () => Unit
   raisePen: ->
     @_withPlot((plot) -> plot.raisePen())
+    return
+
+  # (String) => Unit
+  removePlot: (name) ->
+    upperName = name.toUpperCase()
+    target    = @_lookupPlot(upperName)
+    if target?
+      f = (p) -> if p is target then @_currentPlotMaybe = None
+      fold(->)(f)(@_currentPlotMaybe)
+      delete @_plotMap[upperName]
     return
 
   # () => Unit


### PR DESCRIPTION
This pull request makes a few changes to enable narrowcast (i.e. individualized) plots in HubNet Web:

- `BrowserCompiler.fromNlogo` can now take a compilation request containing extra plots to compile
- `BrowserCompiler` now has a `compilePlots` method that can be used to compile only plot widgets (compiling them against the last cached compilation instance)
- `PlotManager` can now dynamically add and remove plots from its internal state (:frowning_face:)
- `PlotManager` can now lookup plots for a HubNet Web host, using the official name-munging scheme
- A miscellaneous bugfix to `plot.coffee`'s `_withPen` thrown in, just for good measure